### PR TITLE
Fixing deselect mode of the proxy shape command.

### DIFF
--- a/lib/AL_USDMaya/AL/usdmaya/nodes/ProxyShapeSelection.cpp
+++ b/lib/AL_USDMaya/AL/usdmaya/nodes/ProxyShapeSelection.cpp
@@ -1185,7 +1185,7 @@ bool ProxyShape::doSelect(SelectionUndoHelper& helper, const SdfPathVector& orde
           for(uint32_t i = 0; i < helper.m_newSelection.length(); ++i)
           {
             MObject obj;
-            helper.m_newSelection.getDependNode(i, object);
+            helper.m_newSelection.getDependNode(i, obj);
 
             if(object == obj)
             {


### PR DESCRIPTION
There was a small typo in the code. Without this, once the deselect flag was passed, none of the selection commands are working anymore (clear, select etc).