### PR TITLE
some small quality-of-life fixes regarding various tests

### DIFF
--- a/plugin/AL_USDMayaTestPlugin/AL/UnitTestHarness.cpp
+++ b/plugin/AL_USDMayaTestPlugin/AL/UnitTestHarness.cpp
@@ -157,7 +157,7 @@ MStatus UnitTestHarness::doIt(const MArgList& args)
 
   ::testing::InitGoogleTest(&argc, argv);
   int error_code = -1;
-  if(RUN_ALL_TESTS() == 0)
+  if(RUN_ALL_TESTS() == 0 && ::testing::UnitTest::GetInstance()->test_to_run_count() > 0)
   {
     error_code = 0;
   }

--- a/plugin/AL_USDMayaTestPlugin/test_usdmaya.cpp
+++ b/plugin/AL_USDMayaTestPlugin/test_usdmaya.cpp
@@ -33,6 +33,7 @@
 //----------------------------------------------------------------------------------------------------------------------
 void comparePlugs(const MPlug& plugA, const MPlug& plugB, bool usdTesting)
 {
+  SCOPED_TRACE(MString("plugA: ") + plugA.name() + " - plugB: " + plugB.name());
   EXPECT_EQ(plugA.isArray(), plugB.isArray());
   EXPECT_EQ(plugA.isElement(), plugB.isElement());
   EXPECT_EQ(plugA.isCompound(), plugB.isCompound());


### PR DESCRIPTION
some small quality-of-life fixes regarding various tests:

- if NO tests are found, then display the ANGRY / red dino, to make it obvious (as this is usually the result of a mistaken test filter - for a period, I thought my tests were all working fine, when it was actually due to a typo in my test name!)
- in test_usdmaya, add a SCOPED_TRACE statement to comparePlugs, so we can pinpoint where something went wrong