### PR TITLE
make proxyShapeImport command use the --unloaded flag

### DIFF
--- a/lib/AL_USDMaya/AL/usdmaya/cmds/ProxyShapeCommands.cpp
+++ b/lib/AL_USDMaya/AL/usdmaya/cmds/ProxyShapeCommands.cpp
@@ -279,7 +279,7 @@ MStatus ProxyShapeImport::doIt(const MArgList& args)
 
   MString populationMaskIncludePath;
   bool connectToTime = true;
-  bool unloaded = false;
+  bool unloaded = database.isFlagSet("-ul");
 
   // extract command args
   if(!database.isFlagSet("-f") || !database.getFlagArgument("-f", 0, filePath))


### PR DESCRIPTION
...or at least set the attribute correctly on the node. The node itself still seems to load the stage (or at least, it ends up displayed in the viewport), so I'm still not sure this is working correctly, but at least the flag does something now!