### PR TITLE
Fixing a crash when a prim is selected multiple times via the command.

### DIFF
--- a/lib/AL_USDMaya/AL/usdmaya/cmds/ProxyShapeCommands.cpp
+++ b/lib/AL_USDMaya/AL/usdmaya/cmds/ProxyShapeCommands.cpp
@@ -979,7 +979,7 @@ MStatus ProxyShapeSelect::doIt(const MArgList& args)
     {
       throw MS::kFailure;
     }
-    SdfPathVector paths;
+    nodes::SelectionUndoHelper::SdfPathHashSet paths;
 
     MGlobal::ListAdjustment mode = MGlobal::kAddToList;
     if(db.isFlagSet("-cl"))
@@ -998,7 +998,7 @@ MStatus ProxyShapeSelect::doIt(const MArgList& args)
 
         if(!proxy->selectabilityDB().isPathUnselectable(path) && path.IsAbsolutePath())
         {
-          paths.push_back(path);
+          paths.insert(path);
         }
       }
 

--- a/lib/AL_USDMaya/AL/usdmaya/cmds/ProxyShapeCommands.cpp
+++ b/lib/AL_USDMaya/AL/usdmaya/cmds/ProxyShapeCommands.cpp
@@ -979,7 +979,8 @@ MStatus ProxyShapeSelect::doIt(const MArgList& args)
     {
       throw MS::kFailure;
     }
-    nodes::SelectionUndoHelper::SdfPathHashSet paths;
+    SdfPathVector orderedPaths;
+    nodes::SelectionUndoHelper::SdfPathHashSet unorderedPaths;
 
     MGlobal::ListAdjustment mode = MGlobal::kAddToList;
     if(db.isFlagSet("-cl"))
@@ -998,7 +999,10 @@ MStatus ProxyShapeSelect::doIt(const MArgList& args)
 
         if(!proxy->selectabilityDB().isPathUnselectable(path) && path.IsAbsolutePath())
         {
-          paths.insert(path);
+          auto insertResult = unorderedPaths.insert(path);
+          if (insertResult.second) {
+            orderedPaths.push_back(path);
+          }
         }
       }
 
@@ -1024,8 +1028,8 @@ MStatus ProxyShapeSelect::doIt(const MArgList& args)
     }
     const bool isInternal = db.isFlagSet("-i");
 
-    m_helper = new nodes::SelectionUndoHelper(proxy, paths, mode, isInternal);
-    if(!proxy->doSelect(*m_helper))
+    m_helper = new nodes::SelectionUndoHelper(proxy, unorderedPaths, mode, isInternal);
+    if(!proxy->doSelect(*m_helper, orderedPaths))
     {
       delete m_helper;
       m_helper = 0;

--- a/lib/AL_USDMaya/AL/usdmaya/nodes/ProxyDrawOverride.cpp
+++ b/lib/AL_USDMaya/AL/usdmaya/nodes/ProxyDrawOverride.cpp
@@ -352,8 +352,8 @@ void ProxyDrawOverride::draw(const MHWRender::MDrawContext& context, const MUser
     ptr->m_engine->Render(ptr->m_rootPrim, ptr->m_params);
 
     auto view = M3dView::active3dView();
-    const SdfPathVector& paths1 = ptr->m_shape->selectedPaths();
-    const SdfPathVector& paths2 = ptr->m_shape->selectionList().paths();
+    const auto& paths1 = ptr->m_shape->selectedPaths();
+    const auto& paths2 = ptr->m_shape->selectionList().paths();
     SdfPathVector combined;
     combined.reserve(paths1.size() + paths2.size());
     combined.insert(combined.end(), paths1.begin(), paths1.end());

--- a/lib/AL_USDMaya/AL/usdmaya/nodes/ProxyShape.h
+++ b/lib/AL_USDMaya/AL/usdmaya/nodes/ProxyShape.h
@@ -74,7 +74,7 @@ struct SelectionUndoHelper
   /// \param  paths the USD paths to be selected / toggled / unselected
   /// \param  mode the selection mode (add, remove, xor, etc)
   /// \param  internal if the internal flag is set, then modifications to Maya's selection list will NOT occur.
-  SelectionUndoHelper(nodes::ProxyShape* proxy, SdfPathHashSet paths, MGlobal::ListAdjustment mode, bool internal = false);
+  SelectionUndoHelper(nodes::ProxyShape* proxy, const SdfPathHashSet& paths, MGlobal::ListAdjustment mode, bool internal = false);
 
   /// \brief  performs the selection changes
   void doIt();
@@ -572,8 +572,14 @@ public:
   /// \brief  Performs a selection operation on this node. Intended for use by the ProxyShapeSelect command only
   /// \param  helper provides the arguments to the selection system, and stores the internal proxy shape state
   ///         changes that need to be done/undone
+  /// \param  orderedPaths provides the original (deduplicated) input paths, in order; provided just so that the
+  ///         selection commands will return results in the same order they were provided - this is useful so that, if
+  ///         the user does, ie, "AL_usdmaya_ProxyShapeSelect -pp /foo/bar -pp /some/thing -proxy myProxyShape",
+  //          they will get as the result of the command, ["|proxyRoot|foo|bar", "|proxyRoot|some|thing"], and be able
+  //          to know what input SdfPath corresponds to what ouptut maya path
+  SdfPathVector m_pathsOrdered;
   /// \return true if the operation succeeded
-  bool doSelect(SelectionUndoHelper& helper);
+  bool doSelect(SelectionUndoHelper& helper, const SdfPathVector& orderedPaths);
 
   //--------------------------------------------------------------------------------------------------------------------
   /// \name   UsdImaging

--- a/lib/AL_USDMaya/AL/usdmaya/nodes/ProxyShape.h
+++ b/lib/AL_USDMaya/AL/usdmaya/nodes/ProxyShape.h
@@ -67,12 +67,14 @@ namespace nodes {
 //----------------------------------------------------------------------------------------------------------------------
 struct SelectionUndoHelper
 {
+  typedef TfHashSet<SdfPath, SdfPath::Hash> SdfPathHashSet;
+
   /// \brief  Construct with the arguments to select / deselect nodes on a proxy shape
   /// \param  proxy pointer to the maya node on which the selection operation will be performed.
   /// \param  paths the USD paths to be selected / toggled / unselected
   /// \param  mode the selection mode (add, remove, xor, etc)
   /// \param  internal if the internal flag is set, then modifications to Maya's selection list will NOT occur.
-  SelectionUndoHelper(nodes::ProxyShape* proxy, SdfPathVector paths, MGlobal::ListAdjustment mode, bool internal = false);
+  SelectionUndoHelper(nodes::ProxyShape* proxy, SdfPathHashSet paths, MGlobal::ListAdjustment mode, bool internal = false);
 
   /// \brief  performs the selection changes
   void doIt();
@@ -83,8 +85,8 @@ struct SelectionUndoHelper
 private:
   friend class ProxyShape;
   nodes::ProxyShape* m_proxy;
-  SdfPathVector m_paths;
-  SdfPathVector m_previousPaths;
+  SdfPathHashSet m_paths;
+  SdfPathHashSet m_previousPaths;
   MGlobal::ListAdjustment m_mode;
   MDagModifier m_modifier1;
   MDagModifier m_modifier2;
@@ -102,6 +104,7 @@ private:
 class SelectionList
 {
 public:
+  typedef TfHashSet<SdfPath, SdfPath::Hash> SdfPathHashSet;
 
   /// \brief  default ctor
   SelectionList() = default;
@@ -121,17 +124,14 @@ public:
   /// \param  path to add
   inline void add(SdfPath path)
     {
-      if(std::find(m_selected.begin(), m_selected.end(), path) == m_selected.end())
-      {
-        m_selected.push_back(path);
-      }
+      m_selected.insert(path);
     }
 
   /// \brief  removes the path from the selection
   /// \param  path to remove
   inline void remove(SdfPath path)
     {
-      auto it = std::find(m_selected.begin(), m_selected.end(), path);
+      auto it = m_selected.find(path);
       if(it != m_selected.end())
       {
         m_selected.erase(it);
@@ -142,25 +142,21 @@ public:
   /// \param  path to toggle
   inline void toggle(SdfPath path)
     {
-      auto it = std::find(m_selected.begin(), m_selected.end(), path);
-      if(it == m_selected.end())
+      auto insertResult = m_selected.insert(path);
+      if (!insertResult.second)
       {
-        m_selected.push_back(path);
-      }
-      else
-      {
-        m_selected.erase(it);
+        m_selected.erase(insertResult.first);
       }
     }
 
   /// \brief  toggles the path in the selection
   /// \param  path to toggle
   inline bool isSelected(const SdfPath& path) const
-    { return std::find(m_selected.begin(), m_selected.end(), path) != m_selected.end(); }
+    { return m_selected.count(path) > 0; }
 
   /// \brief  the paths in the selection list
   /// \return the selected paths
-  inline const SdfPathVector& paths() const
+  inline const SdfPathHashSet& paths() const
     { return m_selected; }
 
   /// \brief  the paths in the selection list
@@ -169,7 +165,7 @@ public:
     { return m_selected.size(); }
 
 private:
-  SdfPathVector m_selected;
+  SdfPathHashSet m_selected;
 };
 
 //typedef functions
@@ -214,6 +210,8 @@ class ProxyShape
   friend class SelectionUndoHelper;
   friend class ProxyShapeUI;
 public:
+
+  typedef TfHashSet<SdfPath, SdfPath::Hash> SdfPathHashSet;
 
   /// \brief  a mapping between a maya transform (or MObject::kNullObj), and the prim that exists at that location
   ///         in the DAG graph.
@@ -517,8 +515,7 @@ public:
     {
       if(obj == it.second.node())
       {
-        auto iter = std::find(m_selectedPaths.cbegin(), m_selectedPaths.cend(), it.first);
-        if(iter != m_selectedPaths.cend())
+        if(m_selectedPaths.count(it.first) > 0)
         {
           return true;
         }
@@ -569,7 +566,7 @@ public:
 
   /// \brief  returns the paths of the selected items within the proxy shape
   /// \return the paths of the selected prims
-  SdfPathVector& selectedPaths()
+  SdfPathHashSet& selectedPaths()
     { return m_selectedPaths; }
 
   /// \brief  Performs a selection operation on this node. Intended for use by the ProxyShapeSelect command only
@@ -850,7 +847,7 @@ private:
   HierarchyIterationLogic m_findExcludedPrims;
   SelectionList m_selectionList;
   FindUnselectablePrimsLogic m_findUnselectablePrims;
-  SdfPathVector m_selectedPaths;
+  SdfPathHashSet m_selectedPaths;
   FindLockedPrimsLogic m_findLockedPrims;
   std::vector<SdfPath> m_paths;
   std::vector<UsdPrim> m_prims;

--- a/lib/AL_USDMaya/AL/usdmaya/nodes/ProxyShapeSelection.cpp
+++ b/lib/AL_USDMaya/AL/usdmaya/nodes/ProxyShapeSelection.cpp
@@ -417,12 +417,12 @@ MObject ProxyShape::makeUsdTransformChain(
   // special case for selection. Do not allow duplicate paths to be selected.
   if(reason == kSelection)
   {
-    if(std::find(m_selectedPaths.begin(), m_selectedPaths.end(), usdPrim.GetPath()) != m_selectedPaths.end())
+    auto insertResult = m_selectedPaths.insert(usdPrim.GetPath());
+    if(!insertResult.second)
     {
       TransformReferenceMap::iterator previous = m_requiredPaths.find(usdPrim.GetPath());
       return previous->second.node();
     }
-    m_selectedPaths.push_back(usdPrim.GetPath());
   }
 
   TF_DEBUG(ALUSDMAYA_TRANSLATORS).Msg("ProxyShape::makeUsdTransformChain on %s\n", usdPrim.GetPath().GetText());
@@ -749,7 +749,7 @@ void ProxyShape::removeUsdTransformChain(
 
   if(reason == kSelection)
   {
-    auto selectedPath = std::find(m_selectedPaths.begin(), m_selectedPaths.end(), usdPrim.GetPath());
+    auto selectedPath = m_selectedPaths.find(usdPrim.GetPath());
     if(selectedPath != m_selectedPaths.end())
     {
       m_selectedPaths.erase(selectedPath);
@@ -855,7 +855,7 @@ void ProxyShape::insertTransformRefs(const std::vector<std::pair<SdfPath, MObjec
 }
 
 //----------------------------------------------------------------------------------------------------------------------
-SelectionUndoHelper::SelectionUndoHelper(nodes::ProxyShape* proxy, SdfPathVector paths, MGlobal::ListAdjustment mode, bool internal)
+SelectionUndoHelper::SelectionUndoHelper(nodes::ProxyShape* proxy, SdfPathHashSet paths, MGlobal::ListAdjustment mode, bool internal)
   : m_proxy(proxy), m_paths(paths), m_mode(mode), m_modifier1(), m_modifier2(), m_insertedRefs(), m_removedRefs(), m_internal(internal)
 {
 }
@@ -966,7 +966,7 @@ bool ProxyShape::removeAllSelectedNodes(SelectionUndoHelper& helper)
       // now we can delete (without accidentally nuking all parent transforms in the chain)
       helper.m_modifier1.deleteNode(temp);
 
-      SdfPathVector& paths = selectedPaths();
+      auto& paths = selectedPaths();
       for(auto iter = paths.begin(), end = paths.end(); iter != end; ++iter)
       {
         if(*iter ==  (*value)->first)
@@ -1020,15 +1020,7 @@ bool ProxyShape::doSelect(SelectionUndoHelper& helper)
       std::vector<UsdPrim> insertPrims;
       for(auto path : helper.m_paths)
       {
-        bool alreadySelected = false;
-        for(auto it : m_selectedPaths)
-        {
-          if(path == it)
-          {
-            alreadySelected = true;
-            break;
-          }
-        }
+        bool alreadySelected = m_selectedPaths.count(path) > 0;
 
         auto prim = stage->GetPrimAtPath(path);
         if(prim)
@@ -1053,7 +1045,7 @@ bool ProxyShape::doSelect(SelectionUndoHelper& helper)
       uint32_t hasNodesToCreate = 0;
       for(auto prim : insertPrims)
       {
-        m_selectedPaths.push_back(prim.GetPath());
+        m_selectedPaths.insert(prim.GetPath());
         MString pathName;
         MObject object = makeUsdTransformChain_internal(prim, helper.m_modifier1, ProxyShape::kSelection, &helper.m_modifier2, &hasNodesToCreate, &pathName);
         newlySelectedPaths.append(pathName);
@@ -1074,7 +1066,7 @@ bool ProxyShape::doSelect(SelectionUndoHelper& helper)
         else
         {
           addObjToSelectionList(helper.m_newSelection, object);
-          m_selectedPaths.push_back(iter);
+          m_selectedPaths.insert(iter);
         }
       }
 
@@ -1088,15 +1080,7 @@ bool ProxyShape::doSelect(SelectionUndoHelper& helper)
       std::vector<UsdPrim> prims;
       for(auto path : helper.m_paths)
       {
-        bool alreadySelected = false;
-        for(auto it : m_selectedPaths)
-        {
-          if(path == it)
-          {
-            alreadySelected = true;
-            break;
-          }
-        }
+        bool alreadySelected = m_selectedPaths.count(path) > 0;
 
         if(!alreadySelected)
         {
@@ -1108,12 +1092,12 @@ bool ProxyShape::doSelect(SelectionUndoHelper& helper)
         }
       }
 
-      helper.m_paths.insert(helper.m_paths.end(), helper.m_previousPaths.begin(), helper.m_previousPaths.end());
+      helper.m_paths.insert(helper.m_previousPaths.begin(), helper.m_previousPaths.end());
 
       uint32_t hasNodesToCreate = 0;
       for(auto prim : prims)
       {
-        m_selectedPaths.push_back(prim.GetPath());
+        m_selectedPaths.insert(prim.GetPath());
         MString pathName;
         MObject object = makeUsdTransformChain_internal(prim, helper.m_modifier1, ProxyShape::kSelection, &helper.m_modifier2, &hasNodesToCreate, &pathName);
         newlySelectedPaths.append(pathName);
@@ -1128,15 +1112,7 @@ bool ProxyShape::doSelect(SelectionUndoHelper& helper)
       std::vector<UsdPrim> prims;
       for(auto path : helper.m_paths)
       {
-        bool alreadySelected = false;
-        for(auto it : m_selectedPaths)
-        {
-          if(path == it)
-          {
-            alreadySelected = true;
-            break;
-          }
-        }
+        bool alreadySelected = m_selectedPaths.count(path) > 0;
 
         if(alreadySelected)
         {
@@ -1162,7 +1138,7 @@ bool ProxyShape::doSelect(SelectionUndoHelper& helper)
           auto temp = m_requiredPaths.find(prim.GetPath());
           MObject object = temp->second.node();
 
-          m_selectedPaths.erase(std::find(m_selectedPaths.begin(), m_selectedPaths.end(), prim.GetPath()));
+          m_selectedPaths.erase(prim.GetPath());
 
           removeUsdTransformChain_internal(prim, helper.m_modifier1, ProxyShape::kSelection);
           for(int i = 0; i < helper.m_newSelection.length(); ++i)
@@ -1193,15 +1169,7 @@ bool ProxyShape::doSelect(SelectionUndoHelper& helper)
       std::vector<UsdPrim> insertPrims;
       for(auto path : helper.m_paths)
       {
-        bool alreadySelected = false;
-        for(auto it : m_selectedPaths)
-        {
-          if(path == it)
-          {
-            alreadySelected = true;
-            break;
-          }
-        }
+        bool alreadySelected = m_selectedPaths.count(path) > 0;
 
         auto prim = stage->GetPrimAtPath(path);
         if(prim)
@@ -1226,7 +1194,7 @@ bool ProxyShape::doSelect(SelectionUndoHelper& helper)
         auto temp = m_requiredPaths.find(prim.GetPath());
         MObject object = temp->second.node();
 
-        m_selectedPaths.erase(std::find(m_selectedPaths.begin(), m_selectedPaths.end(), prim.GetPath()));
+        m_selectedPaths.erase(prim.GetPath());
 
         removeUsdTransformChain_internal(prim, helper.m_modifier1, ProxyShape::kSelection);
         for(int i = 0; i < helper.m_newSelection.length(); ++i)
@@ -1246,7 +1214,7 @@ bool ProxyShape::doSelect(SelectionUndoHelper& helper)
       uint32_t hasNodesToCreate = 0;
       for(auto prim : insertPrims)
       {
-        m_selectedPaths.push_back(prim.GetPath());
+        m_selectedPaths.insert(prim.GetPath());
         MString pathName;
         MObject object = makeUsdTransformChain_internal(prim, helper.m_modifier1, ProxyShape::kSelection, &helper.m_modifier2, &hasNodesToCreate, &pathName);
         newlySelectedPaths.append(pathName);

--- a/lib/AL_USDMaya/AL/usdmaya/nodes/ProxyShapeUI.cpp
+++ b/lib/AL_USDMaya/AL/usdmaya/nodes/ProxyShapeUI.cpp
@@ -230,11 +230,6 @@ void ProxyShapeUI::draw(const MDrawRequest& request, M3dView& view) const
 
   SdfPathVector paths(shape->selectedPaths().cbegin(), shape->selectedPaths().cend());
   engine->SetSelected(paths);
-//  engine->ClearSelected();
-//  for (auto& path : paths)
-//  {
-//    engine->AddSelected(path, UsdImagingDelegate::ALL_INSTANCES);
-//  }
   engine->SetSelectionColor(GfVec4f(1.0f, 2.0f/3.0f, 0.0f, 1.0f));
   engine->Render(shape->getRootPrim(), params);
 

--- a/lib/AL_USDMaya/AL/usdmaya/nodes/ProxyShapeUI.cpp
+++ b/lib/AL_USDMaya/AL/usdmaya/nodes/ProxyShapeUI.cpp
@@ -228,8 +228,13 @@ void ProxyShapeUI::draw(const MDrawRequest& request, M3dView& view) const
 
   #endif
 
-  auto paths = shape->selectedPaths();
+  SdfPathVector paths(shape->selectedPaths().cbegin(), shape->selectedPaths().cend());
   engine->SetSelected(paths);
+//  engine->ClearSelected();
+//  for (auto& path : paths)
+//  {
+//    engine->AddSelected(path, UsdImagingDelegate::ALL_INSTANCES);
+//  }
   engine->SetSelectionColor(GfVec4f(1.0f, 2.0f/3.0f, 0.0f, 1.0f));
   engine->Render(shape->getRootPrim(), params);
 
@@ -242,6 +247,7 @@ void ProxyShapeUI::draw(const MDrawRequest& request, M3dView& view) const
     engine->RenderBatch(paths, params);
     glDepthFunc(GL_LESS);
   }
+
 
   glClearColor(clearCol[0], clearCol[1], clearCol[2], clearCol[3]);
   glPopClientAttrib();
@@ -535,7 +541,7 @@ bool ProxyShapeUI::select(MSelectInfo& selectInfo, MSelectionList& selectionList
 
     case MGlobal::kXORWithList:
       {
-        SdfPathVector& slpaths = proxyShape->selectedPaths();
+        auto& slpaths = proxyShape->selectedPaths();
         bool hasSelectedItems = false;
         bool hasDeletedItems = false;
 

--- a/plugin/AL_USDMayaTestPlugin/AL/usdmaya/commands/test_ProxyShapeSelect.cpp
+++ b/plugin/AL_USDMayaTestPlugin/AL/usdmaya/commands/test_ProxyShapeSelect.cpp
@@ -107,7 +107,7 @@ TEST(ProxyShapeSelect, selectNode)
 
   // make sure the path is contained in the selected paths (for hydra selection)
   EXPECT_EQ(1, proxy->selectedPaths().size());
-  EXPECT_EQ(SdfPath("/root/hip1/knee1/ankle1/ltoe1"), proxy->selectedPaths()[0]);
+  EXPECT_EQ(1, proxy->selectedPaths().count(SdfPath("/root/hip1/knee1/ankle1/ltoe1")));
   EXPECT_TRUE(proxy->isRequiredPath(SdfPath("/root")));
   EXPECT_TRUE(proxy->isRequiredPath(SdfPath("/root/hip1")));
   EXPECT_TRUE(proxy->isRequiredPath(SdfPath("/root/hip1/knee1")));
@@ -132,7 +132,7 @@ TEST(ProxyShapeSelect, selectNode)
   MGlobal::executeCommand("redo", false, true);
 
   EXPECT_EQ(1, proxy->selectedPaths().size());
-  EXPECT_EQ(SdfPath("/root/hip1/knee1/ankle1/ltoe1"), proxy->selectedPaths()[0]);
+  EXPECT_EQ(1, proxy->selectedPaths().count(SdfPath("/root/hip1/knee1/ankle1/ltoe1")));
   EXPECT_TRUE(proxy->isRequiredPath(SdfPath("/root")));
   EXPECT_TRUE(proxy->isRequiredPath(SdfPath("/root/hip1")));
   EXPECT_TRUE(proxy->isRequiredPath(SdfPath("/root/hip1/knee1")));
@@ -150,8 +150,8 @@ TEST(ProxyShapeSelect, selectNode)
   results.clear();
 
   EXPECT_EQ(2, proxy->selectedPaths().size());
-  EXPECT_EQ(SdfPath("/root/hip2/knee2/ankle2/ltoe2"), proxy->selectedPaths()[0]);
-  EXPECT_EQ(SdfPath("/root/hip2/knee2/ankle2/rtoe2"), proxy->selectedPaths()[1]);
+  EXPECT_EQ(1, proxy->selectedPaths().count(SdfPath("/root/hip2/knee2/ankle2/ltoe2")));
+  EXPECT_EQ(1, proxy->selectedPaths().count(SdfPath("/root/hip2/knee2/ankle2/rtoe2")));
   EXPECT_TRUE(proxy->isRequiredPath(SdfPath("/root")));
   EXPECT_TRUE(proxy->isRequiredPath(SdfPath("/root/hip2")));
   EXPECT_TRUE(proxy->isRequiredPath(SdfPath("/root/hip2/knee2")));
@@ -168,7 +168,7 @@ TEST(ProxyShapeSelect, selectNode)
   MGlobal::executeCommand("undo", false, true);
 
   EXPECT_EQ(1, proxy->selectedPaths().size());
-  EXPECT_EQ(SdfPath("/root/hip1/knee1/ankle1/ltoe1"), proxy->selectedPaths()[0]);
+  EXPECT_EQ(1, proxy->selectedPaths().count(SdfPath("/root/hip1/knee1/ankle1/ltoe1")));
   EXPECT_TRUE(proxy->isRequiredPath(SdfPath("/root")));
   EXPECT_TRUE(proxy->isRequiredPath(SdfPath("/root/hip1")));
   EXPECT_TRUE(proxy->isRequiredPath(SdfPath("/root/hip1/knee1")));
@@ -184,8 +184,8 @@ TEST(ProxyShapeSelect, selectNode)
   MGlobal::executeCommand("redo", false, true);
 
   EXPECT_EQ(2, proxy->selectedPaths().size());
-  EXPECT_EQ(SdfPath("/root/hip2/knee2/ankle2/ltoe2"), proxy->selectedPaths()[0]);
-  EXPECT_EQ(SdfPath("/root/hip2/knee2/ankle2/rtoe2"), proxy->selectedPaths()[1]);
+  EXPECT_EQ(1, proxy->selectedPaths().count(SdfPath("/root/hip2/knee2/ankle2/ltoe2")));
+  EXPECT_EQ(1, proxy->selectedPaths().count(SdfPath("/root/hip2/knee2/ankle2/rtoe2")));
   EXPECT_TRUE(proxy->isRequiredPath(SdfPath("/root")));
   EXPECT_TRUE(proxy->isRequiredPath(SdfPath("/root/hip2")));
   EXPECT_TRUE(proxy->isRequiredPath(SdfPath("/root/hip2/knee2")));
@@ -220,8 +220,8 @@ TEST(ProxyShapeSelect, selectNode)
   MGlobal::executeCommand("undo", false, true);
 
   EXPECT_EQ(2, proxy->selectedPaths().size());
-  EXPECT_EQ(SdfPath("/root/hip2/knee2/ankle2/ltoe2"), proxy->selectedPaths()[0]);
-  EXPECT_EQ(SdfPath("/root/hip2/knee2/ankle2/rtoe2"), proxy->selectedPaths()[1]);
+  EXPECT_EQ(1, proxy->selectedPaths().count(SdfPath("/root/hip2/knee2/ankle2/ltoe2")));
+  EXPECT_EQ(1, proxy->selectedPaths().count(SdfPath("/root/hip2/knee2/ankle2/rtoe2")));
   EXPECT_TRUE(proxy->isRequiredPath(SdfPath("/root")));
   EXPECT_TRUE(proxy->isRequiredPath(SdfPath("/root/hip2")));
   EXPECT_TRUE(proxy->isRequiredPath(SdfPath("/root/hip2/knee2")));
@@ -797,3 +797,106 @@ TEST(ProxyShapeSelect, selectSamePathTwiceViaMaya)
   EXPECT_EQ(0, refCount);
 }
 
+TEST(ProxyShapeSelect, repeatedSelection)
+{
+  MFileIO::newFile(true);
+  // unsure undo is enabled for this test
+  MGlobal::executeCommand("undoInfo -state 1;");
+
+  auto constructTransformChain = []() {
+    UsdStageRefPtr stage = UsdStage::CreateInMemory();
+
+    UsdGeomXform::Define(stage, SdfPath("/root"));
+    UsdGeomXform::Define(stage, SdfPath("/root/hip1"));
+    return stage;
+  };
+
+  auto assertSelected = [](MString objName, const SdfPath& path, AL::usdmaya::nodes::ProxyShape *proxy) {
+    MSelectionList sl;
+    MGlobal::getActiveSelectionList(sl);
+    MStringArray selStrings;
+    sl.getSelectionStrings(selStrings);
+    ASSERT_EQ(1, selStrings.length());
+    ASSERT_EQ(objName, selStrings[0]);
+
+    // Make sure it's only selected ONCE!
+    auto& selectedPaths = proxy->selectedPaths();
+    ASSERT_EQ(1, selectedPaths.size());
+    size_t pathCount = 0;
+    for (auto& it : proxy->selectedPaths()) {
+      if (it == path) {
+        pathCount += 1;
+      }
+    }
+    ASSERT_EQ(1, pathCount);
+  };
+
+  auto assertNothingSelected = [](AL::usdmaya::nodes::ProxyShape *proxy) {
+    MSelectionList sl;
+    MGlobal::getActiveSelectionList(sl);
+    ASSERT_EQ(0, sl.length());
+    ASSERT_EQ(0, proxy->selectedPaths().size());
+  };
+
+  const std::string temp_path = "/tmp/AL_USDMayaTests_repeatedSelection.usda";
+
+  // generate some data for the proxy shape
+  {
+    auto stage = constructTransformChain();
+    stage->Export(temp_path, false);
+  }
+
+  MFnDagNode fn;
+  MObject xform = fn.create("transform");
+  MObject shape = fn.create("AL_usdmaya_ProxyShape", xform);
+  MString shapeName = fn.name();
+
+  SdfPath hipPath("/root/hip1");
+  AL::usdmaya::nodes::ProxyShape *proxy = (AL::usdmaya::nodes::ProxyShape *) fn.userNode();
+
+  // force the stage to load
+  proxy->filePathPlug().setString(temp_path.c_str());
+  MStringArray results;
+
+  // select a single path
+  MGlobal::executeCommand("select -cl;");
+  MGlobal::executeCommand("AL_usdmaya_ProxyShapeSelect -a -pp \"/root/hip1\" -pp \"/root/hip1\" -pp \"/root/hip1\" \"AL_usdmaya_ProxyShape1\"", results,
+                          false, true);
+  // Make sure it's selected
+  { SCOPED_TRACE(""); assertSelected("hip1", hipPath, proxy); }
+
+  // select it again
+  MGlobal::executeCommand("AL_usdmaya_ProxyShapeSelect -a -pp \"/root/hip1\" -pp \"/root/hip1\" -pp \"/root/hip1\" \"AL_usdmaya_ProxyShape1\"", results,
+                          false, true);
+  // Make sure it's still selected
+  { SCOPED_TRACE(""); assertSelected("hip1", hipPath, proxy); }
+
+  // deselect it
+  MGlobal::executeCommand("AL_usdmaya_ProxyShapeSelect -d -pp \"/root/hip1\" \"AL_usdmaya_ProxyShape1\"", results,
+                          false, true);
+  { SCOPED_TRACE(""); assertNothingSelected(proxy); }
+
+  // make sure undo /redo work as expected
+  MGlobal::executeCommand("undo", false, true);
+  { SCOPED_TRACE(""); assertSelected("hip1", hipPath, proxy); }
+  MGlobal::executeCommand("redo", false, true);
+  { SCOPED_TRACE(""); assertNothingSelected(proxy); }
+  MGlobal::executeCommand("undo", false, true);
+  { SCOPED_TRACE(""); assertSelected("hip1", hipPath, proxy); }
+  MGlobal::executeCommand("undo", false, true);
+  { SCOPED_TRACE(""); assertSelected("hip1", hipPath, proxy); }
+  MGlobal::executeCommand("undo", false, true);
+  { SCOPED_TRACE(""); assertNothingSelected(proxy); }
+  MGlobal::executeCommand("redo", false, true);
+  { SCOPED_TRACE(""); assertSelected("hip1", hipPath, proxy); }
+  MGlobal::executeCommand("redo", false, true);
+  { SCOPED_TRACE(""); assertSelected("hip1", hipPath, proxy); }
+  MGlobal::executeCommand("redo", false, true);
+  { SCOPED_TRACE(""); assertNothingSelected(proxy); }
+  MGlobal::executeCommand("undo", false, true);
+  { SCOPED_TRACE(""); assertSelected("hip1", hipPath, proxy); }
+  MGlobal::executeCommand("undo", false, true);
+  { SCOPED_TRACE(""); assertSelected("hip1", hipPath, proxy); }
+  MGlobal::executeCommand("undo", false, true);
+  { SCOPED_TRACE(""); assertNothingSelected(proxy); }
+}


### PR DESCRIPTION
Doing this by replacing SdfPathVector(s) with SdfPathHashSets, to ensure uniqueness.

Should also be more efficient, as we do many membership queries (which are much faster with a hash set for large selections).