### PR TITLE
Unloads instead of deletes the associated maya reference when the ALMayaReference is (temporarily) removed

### DIFF
--- a/lib/AL_USDMaya/AL/usdmaya/nodes/ProxyShape.cpp
+++ b/lib/AL_USDMaya/AL/usdmaya/nodes/ProxyShape.cpp
@@ -40,6 +40,7 @@
 
 #include "maya/MFileIO.h"
 #include "maya/MFnPluginData.h"
+#include "maya/MFnReference.h"
 #include "maya/MHWGeometryUtilities.h"
 #include "maya/MItDependencyNodes.h"
 #include "maya/MPlugArray.h"
@@ -1605,14 +1606,13 @@ void ProxyShape::unloadMayaReferences()
           MObject temp = plugs[i].node();
           if(temp.hasFn(MFn::kReference))
           {
-            MString command = MString("referenceQuery -filename ") + MFnDependencyNode(temp).name();
-            MString referenceFilename;
-            MStatus returnStatus = MGlobal::executeCommand(command, referenceFilename);
-            if (returnStatus != MStatus::kFailure)
-            {
-              TF_DEBUG(ALUSDMAYA_EVALUATION).Msg("ProxyShape::unloadMayaReferences removing %s\n", referenceFilename.asChar());
-              MFileIO::removeReference(referenceFilename);
-            }
+            MFnReference mfnRef(temp);
+            MString referenceFilename = mfnRef.fileName(
+                true /*resolvedName*/,
+                true /*includePath*/,
+                true /*includeCopyNumber*/);
+            TF_DEBUG(ALUSDMAYA_EVALUATION).Msg("ProxyShape::unloadMayaReferences unloading %s\n", referenceFilename.asChar());
+            MFileIO::unloadReferenceByNode(temp);
           }
         }
       }

--- a/plugin/AL_USDMayaTestPlugin/AL/usdmaya/nodes/test_ActiveInactive.cpp
+++ b/plugin/AL_USDMayaTestPlugin/AL/usdmaya/nodes/test_ActiveInactive.cpp
@@ -45,6 +45,7 @@ static const char* const g_inactive =
 "    )\n"
 "    {\n"
 "      asset mayaReference = \"/tmp/AL_USDMayaTests_cube.ma\"\n"
+"      string mayaNamespace = \"cube\"\n"
 "    }\n"
 "}\n";
 
@@ -56,6 +57,7 @@ static const char* const g_active =
 "    def ALMayaReference \"rig\"\n"
 "    {\n"
 "      asset mayaReference = \"/tmp/AL_USDMayaTests_cube.ma\"\n"
+"      string mayaNamespace = \"cube\"\n"
 "    }\n"
 "}\n";
 
@@ -114,6 +116,7 @@ static const char* const g_customTransformType =
 "    )\n"
 "    {\n"
 "      asset mayaReference = \"/tmp/AL_USDMayaTests_cube.ma\"\n"
+"      string mayaNamespace = \"cube\"\n"
 "    }\n"
 "}\n";
 
@@ -129,6 +132,7 @@ static const char* const g_duplicateTransformNames =
 "    )\n"
 "    {\n"
 "      asset mayaReference = \"/tmp/AL_USDMayaTests_cube.ma\"\n"
+"      string mayaNamespace = \"cube\"\n"
 "    }\n"
 "  }\n"
 "  def Xform \"two\"\n"
@@ -138,6 +142,7 @@ static const char* const g_duplicateTransformNames =
 "    )\n"
 "    {\n"
 "      asset mayaReference = \"/tmp/AL_USDMayaTests_sphere.ma\"\n"
+"      string mayaNamespace = \"cube\"\n"
 "    }\n"
 "  }\n"
 "}\n";
@@ -254,9 +259,9 @@ TEST(ActiveInactive, customTransformType)
 
     // should not be able to select the items in the reference file
     MSelectionList sl;
-    EXPECT_TRUE(bool(sl.add("AL_USDMayaTests_cube:pCube1")));
-    EXPECT_TRUE(bool(sl.add("AL_USDMayaTests_cube:pCubeShape1")));
-    EXPECT_TRUE(bool(sl.add("AL_USDMayaTests_cube:polyCube1")));
+    EXPECT_TRUE(bool(sl.add("cube:pCube1")));
+    EXPECT_TRUE(bool(sl.add("cube:pCubeShape1")));
+    EXPECT_TRUE(bool(sl.add("cube:polyCube1")));
     EXPECT_EQ(3, sl.length());
     sl.clear();
 
@@ -270,9 +275,9 @@ TEST(ActiveInactive, customTransformType)
     // activate the prim
     MGlobal::executeCommand("AL_usdmaya_ActivatePrim -a false -pp \"/root/rig\" \"AL_usdmaya_ProxyShape1\"", false, false);
 
-    EXPECT_FALSE(bool(sl.add("AL_USDMayaTests_cube:pCube1")));
-    EXPECT_FALSE(bool(sl.add("AL_USDMayaTests_cube:pCubeShape1")));
-    EXPECT_FALSE(bool(sl.add("AL_USDMayaTests_cube:polyCube1")));
+    EXPECT_FALSE(bool(sl.add("cube:pCube1")));
+    EXPECT_FALSE(bool(sl.add("cube:pCubeShape1")));
+    EXPECT_FALSE(bool(sl.add("cube:polyCube1")));
     EXPECT_EQ(0, sl.length());
 
     MFileIO::saveAs("/tmp/AL_USDMayaTests_customTransformTypeInactive.ma", 0, true);
@@ -281,9 +286,9 @@ TEST(ActiveInactive, customTransformType)
     MGlobal::executeCommand("AL_usdmaya_ActivatePrim -a true -pp \"/root/rig\" \"AL_usdmaya_ProxyShape1\"", false, false);
 
     // should now be able to select the items in the reference file
-    EXPECT_TRUE(bool(sl.add("AL_USDMayaTests_cube:pCube1")));
-    EXPECT_TRUE(bool(sl.add("AL_USDMayaTests_cube:pCubeShape1")));
-    EXPECT_TRUE(bool(sl.add("AL_USDMayaTests_cube:polyCube1")));
+    EXPECT_TRUE(bool(sl.add("cube:pCube1")));
+    EXPECT_TRUE(bool(sl.add("cube:pCubeShape1")));
+    EXPECT_TRUE(bool(sl.add("cube:polyCube1")));
     EXPECT_EQ(3, sl.length());
     sl.clear();
   }
@@ -303,24 +308,24 @@ TEST(ActiveInactive, customTransformType)
 
     // should not be able to select the items in the reference file
     MSelectionList sl;
-    EXPECT_TRUE(bool(sl.add("AL_USDMayaTests_cube:pCube1")));
-    EXPECT_TRUE(bool(sl.add("AL_USDMayaTests_cube:pCubeShape1")));
-    EXPECT_TRUE(bool(sl.add("AL_USDMayaTests_cube:polyCube1")));
+    EXPECT_TRUE(bool(sl.add("cube:pCube1")));
+    EXPECT_TRUE(bool(sl.add("cube:pCubeShape1")));
+    EXPECT_TRUE(bool(sl.add("cube:polyCube1")));
     EXPECT_EQ(3, sl.length());
     sl.clear();
 
     // activate the prim
     MGlobal::executeCommand("AL_usdmaya_ActivatePrim -a false -pp \"/root/rig\" \"AL_usdmaya_ProxyShape1\"", false, false);
-    EXPECT_FALSE(bool(sl.add("AL_USDMayaTests_cube:pCube1")));
-    EXPECT_FALSE(bool(sl.add("AL_USDMayaTests_cube:pCubeShape1")));
-    EXPECT_FALSE(bool(sl.add("AL_USDMayaTests_cube:polyCube1")));
+    EXPECT_FALSE(bool(sl.add("cube:pCube1")));
+    EXPECT_FALSE(bool(sl.add("cube:pCubeShape1")));
+    EXPECT_FALSE(bool(sl.add("cube:polyCube1")));
     EXPECT_EQ(0, sl.length());
 
     // activate the prim
     MGlobal::executeCommand("AL_usdmaya_ActivatePrim -a true -pp \"/root/rig\" \"AL_usdmaya_ProxyShape1\"", false, false);
-    EXPECT_TRUE(bool(sl.add("AL_USDMayaTests_cube:pCube1")));
-    EXPECT_TRUE(bool(sl.add("AL_USDMayaTests_cube:pCubeShape1")));
-    EXPECT_TRUE(bool(sl.add("AL_USDMayaTests_cube:polyCube1")));
+    EXPECT_TRUE(bool(sl.add("cube:pCube1")));
+    EXPECT_TRUE(bool(sl.add("cube:pCubeShape1")));
+    EXPECT_TRUE(bool(sl.add("cube:polyCube1")));
     EXPECT_EQ(3, sl.length());
     sl.clear();
   }
@@ -340,24 +345,24 @@ TEST(ActiveInactive, customTransformType)
 
     // should not be able to select the items in the reference file
     MSelectionList sl;
-    EXPECT_FALSE(bool(sl.add("AL_USDMayaTests_cube:pCube1")));
-    EXPECT_FALSE(bool(sl.add("AL_USDMayaTests_cube:pCubeShape1")));
-    EXPECT_FALSE(bool(sl.add("AL_USDMayaTests_cube:polyCube1")));
+    EXPECT_FALSE(bool(sl.add("cube:pCube1")));
+    EXPECT_FALSE(bool(sl.add("cube:pCubeShape1")));
+    EXPECT_FALSE(bool(sl.add("cube:polyCube1")));
     EXPECT_EQ(0, sl.length());
 
     // deactivate the prim
     MGlobal::executeCommand("AL_usdmaya_ActivatePrim -a true -pp \"/root/rig\" \"AL_usdmaya_ProxyShape1\"", false, false);
-    EXPECT_TRUE(bool(sl.add("AL_USDMayaTests_cube:pCube1")));
-    EXPECT_TRUE(bool(sl.add("AL_USDMayaTests_cube:pCubeShape1")));
-    EXPECT_TRUE(bool(sl.add("AL_USDMayaTests_cube:polyCube1")));
+    EXPECT_TRUE(bool(sl.add("cube:pCube1")));
+    EXPECT_TRUE(bool(sl.add("cube:pCubeShape1")));
+    EXPECT_TRUE(bool(sl.add("cube:polyCube1")));
     EXPECT_EQ(3, sl.length());
     sl.clear();
 
     // activate the prim
     MGlobal::executeCommand("AL_usdmaya_ActivatePrim -a false -pp \"/root/rig\" \"AL_usdmaya_ProxyShape1\"", false, false);
-    EXPECT_FALSE(bool(sl.add("AL_USDMayaTests_cube:pCube1")));
-    EXPECT_FALSE(bool(sl.add("AL_USDMayaTests_cube:pCubeShape1")));
-    EXPECT_FALSE(bool(sl.add("AL_USDMayaTests_cube:polyCube1")));
+    EXPECT_FALSE(bool(sl.add("cube:pCube1")));
+    EXPECT_FALSE(bool(sl.add("cube:pCubeShape1")));
+    EXPECT_FALSE(bool(sl.add("cube:polyCube1")));
     EXPECT_EQ(0, sl.length());
   }
 }
@@ -411,18 +416,18 @@ TEST(ActiveInactive, disable)
 
     // should not be able to select the items in the reference file
     MSelectionList sl;
-    EXPECT_FALSE(bool(sl.add("AL_USDMayaTests_cube:pCube1")));
-    EXPECT_FALSE(bool(sl.add("AL_USDMayaTests_cube:pCubeShape1")));
-    EXPECT_FALSE(bool(sl.add("AL_USDMayaTests_cube:polyCube1")));
+    EXPECT_FALSE(bool(sl.add("cube:pCube1")));
+    EXPECT_FALSE(bool(sl.add("cube:pCubeShape1")));
+    EXPECT_FALSE(bool(sl.add("cube:polyCube1")));
     EXPECT_EQ(0, sl.length());
 
     // activate the prim
     MGlobal::executeCommand("AL_usdmaya_ActivatePrim -a true -pp \"/root/rig\" \"AL_usdmaya_ProxyShape1\"", false, false);
 
     // should now be able to select the items in the reference file
-    EXPECT_TRUE(bool(sl.add("AL_USDMayaTests_cube:pCube1")));
-    EXPECT_TRUE(bool(sl.add("AL_USDMayaTests_cube:pCubeShape1")));
-    EXPECT_TRUE(bool(sl.add("AL_USDMayaTests_cube:polyCube1")));
+    EXPECT_TRUE(bool(sl.add("cube:pCube1")));
+    EXPECT_TRUE(bool(sl.add("cube:pCubeShape1")));
+    EXPECT_TRUE(bool(sl.add("cube:polyCube1")));
     EXPECT_EQ(3, sl.length());
     sl.clear();
 
@@ -430,18 +435,18 @@ TEST(ActiveInactive, disable)
     MGlobal::executeCommand("AL_usdmaya_ActivatePrim -a false -pp \"/root/rig\" \"AL_usdmaya_ProxyShape1\"", false, false);
 
     // should now be able to select the items in the reference file
-    EXPECT_FALSE(bool(sl.add("AL_USDMayaTests_cube:pCube1")));
-    EXPECT_FALSE(bool(sl.add("AL_USDMayaTests_cube:pCubeShape1")));
-    EXPECT_FALSE(bool(sl.add("AL_USDMayaTests_cube:polyCube1")));
+    EXPECT_FALSE(bool(sl.add("cube:pCube1")));
+    EXPECT_FALSE(bool(sl.add("cube:pCubeShape1")));
+    EXPECT_FALSE(bool(sl.add("cube:polyCube1")));
     EXPECT_EQ(0, sl.length());
 
     // activate the prim
     MGlobal::executeCommand("AL_usdmaya_ActivatePrim -a true -pp \"/root/rig\" \"AL_usdmaya_ProxyShape1\"", false, false);
 
     // should now be able to select the items in the reference file
-    EXPECT_TRUE(bool(sl.add("AL_USDMayaTests_cube:pCube1")));
-    EXPECT_TRUE(bool(sl.add("AL_USDMayaTests_cube:pCubeShape1")));
-    EXPECT_TRUE(bool(sl.add("AL_USDMayaTests_cube:polyCube1")));
+    EXPECT_TRUE(bool(sl.add("cube:pCube1")));
+    EXPECT_TRUE(bool(sl.add("cube:pCubeShape1")));
+    EXPECT_TRUE(bool(sl.add("cube:polyCube1")));
     EXPECT_EQ(3, sl.length());
     sl.clear();
   }
@@ -467,27 +472,27 @@ TEST(ActiveInactive, disable)
 
     // should be able to select the items in the reference file
     MSelectionList sl;
-    EXPECT_TRUE(bool(sl.add("AL_USDMayaTests_cube:pCube1")));
-    EXPECT_TRUE(bool(sl.add("AL_USDMayaTests_cube:pCubeShape1")));
-    EXPECT_TRUE(bool(sl.add("AL_USDMayaTests_cube:polyCube1")));
+    EXPECT_TRUE(bool(sl.add("cube:pCube1")));
+    EXPECT_TRUE(bool(sl.add("cube:pCubeShape1")));
+    EXPECT_TRUE(bool(sl.add("cube:polyCube1")));
     EXPECT_EQ(3, sl.length());
     sl.clear();
 
     // activate the prim
     MGlobal::executeCommand("AL_usdmaya_ActivatePrim -a false -pp \"/root/rig\" \"AL_usdmaya_ProxyShape1\"", false, false);
 
-    EXPECT_FALSE(bool(sl.add("AL_USDMayaTests_cube:pCube1")));
-    EXPECT_FALSE(bool(sl.add("AL_USDMayaTests_cube:pCubeShape1")));
-    EXPECT_FALSE(bool(sl.add("AL_USDMayaTests_cube:polyCube1")));
+    EXPECT_FALSE(bool(sl.add("cube:pCube1")));
+    EXPECT_FALSE(bool(sl.add("cube:pCubeShape1")));
+    EXPECT_FALSE(bool(sl.add("cube:polyCube1")));
     EXPECT_EQ(0, sl.length());
 
     // activate the prim
     MGlobal::executeCommand("AL_usdmaya_ActivatePrim -a true -pp \"/root/rig\" \"AL_usdmaya_ProxyShape1\"", false, false);
 
     // should now be able to select the items in the reference file
-    EXPECT_TRUE(bool(sl.add("AL_USDMayaTests_cube:pCube1")));
-    EXPECT_TRUE(bool(sl.add("AL_USDMayaTests_cube:pCubeShape1")));
-    EXPECT_TRUE(bool(sl.add("AL_USDMayaTests_cube:polyCube1")));
+    EXPECT_TRUE(bool(sl.add("cube:pCube1")));
+    EXPECT_TRUE(bool(sl.add("cube:pCubeShape1")));
+    EXPECT_TRUE(bool(sl.add("cube:polyCube1")));
     EXPECT_EQ(3, sl.length());
     sl.clear();
 
@@ -495,9 +500,9 @@ TEST(ActiveInactive, disable)
     MGlobal::executeCommand("AL_usdmaya_ActivatePrim -a false -pp \"/root/rig\" \"AL_usdmaya_ProxyShape1\"", false, false);
 
     // should now be able to select the items in the reference file
-    EXPECT_FALSE(bool(sl.add("AL_USDMayaTests_cube:pCube1")));
-    EXPECT_FALSE(bool(sl.add("AL_USDMayaTests_cube:pCubeShape1")));
-    EXPECT_FALSE(bool(sl.add("AL_USDMayaTests_cube:polyCube1")));
+    EXPECT_FALSE(bool(sl.add("cube:pCube1")));
+    EXPECT_FALSE(bool(sl.add("cube:pCubeShape1")));
+    EXPECT_FALSE(bool(sl.add("cube:polyCube1")));
     EXPECT_EQ(0, sl.length());
   }
 
@@ -680,9 +685,9 @@ TEST(ActiveInactive, disable)
 
       // should not be able to select the items in the reference file
       MSelectionList sl;
-      EXPECT_TRUE(bool(sl.add("AL_USDMayaTests_cube:pCube1")));
-      EXPECT_TRUE(bool(sl.add("AL_USDMayaTests_cube:pCubeShape1")));
-      EXPECT_TRUE(bool(sl.add("AL_USDMayaTests_cube:polyCube1")));
+      EXPECT_TRUE(bool(sl.add("cube:pCube1")));
+      EXPECT_TRUE(bool(sl.add("cube:pCubeShape1")));
+      EXPECT_TRUE(bool(sl.add("cube:polyCube1")));
       EXPECT_EQ(3, sl.length());
       sl.clear();
 
@@ -690,9 +695,9 @@ TEST(ActiveInactive, disable)
       MGlobal::executeCommand("AL_usdmaya_ActivatePrim -a false -pp \"/root/rig\" \"AL_usdmaya_ProxyShape1\"", false, false);
 
       // should now be able to select the items in the reference file
-      EXPECT_FALSE(bool(sl.add("AL_USDMayaTests_cube:pCube1")));
-      EXPECT_FALSE(bool(sl.add("AL_USDMayaTests_cube:pCubeShape1")));
-      EXPECT_FALSE(bool(sl.add("AL_USDMayaTests_cube:polyCube1")));
+      EXPECT_FALSE(bool(sl.add("cube:pCube1")));
+      EXPECT_FALSE(bool(sl.add("cube:pCubeShape1")));
+      EXPECT_FALSE(bool(sl.add("cube:polyCube1")));
       EXPECT_EQ(0, sl.length());
 
       MFileIO::saveAs("/tmp/AL_USDMayaTests_inactive_prim.ma", 0, true);
@@ -714,17 +719,17 @@ TEST(ActiveInactive, disable)
     AL::usdmaya::nodes::ProxyShape* proxy = (AL::usdmaya::nodes::ProxyShape*)fn.userNode();
     EXPECT_TRUE(proxy != 0);
 
-    EXPECT_FALSE(bool(sl.add("AL_USDMayaTests_cube:pCube1")));
-    EXPECT_FALSE(bool(sl.add("AL_USDMayaTests_cube:pCubeShape1")));
-    EXPECT_FALSE(bool(sl.add("AL_USDMayaTests_cube:polyCube1")));
+    EXPECT_FALSE(bool(sl.add("cube:pCube1")));
+    EXPECT_FALSE(bool(sl.add("cube:pCubeShape1")));
+    EXPECT_FALSE(bool(sl.add("cube:polyCube1")));
     EXPECT_EQ(0, sl.length());
 
     // activate the prim, this should ensure the
     MGlobal::executeCommand("AL_usdmaya_ActivatePrim -a true -pp \"/root/rig\" \"AL_usdmaya_ProxyShape1\"", false, false);
 
-    EXPECT_TRUE(bool(sl.add("AL_USDMayaTests_cube:pCube1")));
-    EXPECT_TRUE(bool(sl.add("AL_USDMayaTests_cube:pCubeShape1")));
-    EXPECT_TRUE(bool(sl.add("AL_USDMayaTests_cube:polyCube1")));
+    EXPECT_TRUE(bool(sl.add("cube:pCube1")));
+    EXPECT_TRUE(bool(sl.add("cube:pCubeShape1")));
+    EXPECT_TRUE(bool(sl.add("cube:polyCube1")));
     EXPECT_EQ(3, sl.length());
     sl.clear();
   }

--- a/plugin/AL_USDMayaTestPlugin/AL/usdmaya/nodes/test_TranslatorContext.cpp
+++ b/plugin/AL_USDMayaTestPlugin/AL/usdmaya/nodes/test_TranslatorContext.cpp
@@ -90,6 +90,7 @@ static const char* const g_simpleRig =
 "    def ALMayaReference \"rig\""
 "    {\n"
 "      asset mayaReference = \"/tmp/AL_USDMayaTests_cube.ma\"\n"
+"      string mayaNamespace = \"cube\"\n"
 "    }\n"
 "}\n";
 
@@ -179,11 +180,13 @@ TEST(TranslatorContext, TranslatorContext)
       {
         AL::usdmaya::fileio::translators::MObjectHandleArray handles;
         context->getMObjects(SdfPath("/root/rig"), handles);
+        ASSERT_EQ(handles.size(), 1);
         EXPECT_TRUE(handles[0].object() == obj);
       }
       {
         AL::usdmaya::fileio::translators::MObjectHandleArray handles;
         context->getMObjects(prim, handles);
+        ASSERT_EQ(handles.size(), 1);
         EXPECT_TRUE(handles[0].object() == obj);
       }
       context->removeItems(prim);
@@ -212,6 +215,7 @@ TEST(TranslatorContext, TranslatorContext)
       {
         AL::usdmaya::fileio::translators::MObjectHandleArray handles;
         context->getMObjects(SdfPath("/root/rig"), handles);
+        ASSERT_EQ(handles.size(), 1);
         EXPECT_TRUE(handles[0].object() == obj);
       }
       token = context->getTypeForPath(SdfPath("/root/rig"));

--- a/translators/MayaReference.cpp
+++ b/translators/MayaReference.cpp
@@ -126,7 +126,7 @@ MStatus MayaReferenceLogic::update(const UsdPrim& prim, MObject parent) const
         MObject temp = referencePlugs[i].node();
         if(temp.hasFn(MFn::kReference))
         {
-          MFnDependencyNode fnReference(temp);
+          MFnReference fnReference(temp);
           command = MString("referenceQuery -f \"") + fnReference.name() + "\"";
           MGlobal::executeCommand(command, filepath);
           TF_DEBUG(ALUSDMAYA_TRANSLATORS).Msg("MayaReferenceLogic::update referenceNode=%s prim=%s execute \"%s\"=%s\n",
@@ -184,12 +184,22 @@ MStatus MayaReferenceLogic::update(const UsdPrim& prim, MObject parent) const
             }
             else
             {
-              TF_DEBUG(ALUSDMAYA_TRANSLATORS).Msg("MayaReferenceLogic::update prim=%s loadReferenceByNode\n", prim.GetPath().GetText());
-              MString s = MFileIO::loadReferenceByNode(temp, &status);
+              // Check to see if reference is already loaded - if so, don't need to do anything!
+              if (fnReference.isLoaded())
+              {
+                TF_DEBUG(ALUSDMAYA_TRANSLATORS).Msg("MayaReferenceLogic::update prim=%s already loaded with correct path\n", prim.GetPath().GetText());
+              }
+              else
+              {
+                TF_DEBUG(ALUSDMAYA_TRANSLATORS).Msg("MayaReferenceLogic::update prim=%s loadReferenceByNode\n", prim.GetPath().GetText());
+                MString s = MFileIO::loadReferenceByNode(temp, &status);
+              }
             }
           }
           else
           {
+            // Can unconditionally unload, as unloading an already unloaded reference
+            // won't do anything, and won't error
             TF_DEBUG(ALUSDMAYA_TRANSLATORS).Msg("MayaReferenceLogic::update prim=%s unloadReferenceByNode\n", prim.GetPath().GetText());
             MString s = MFileIO::unloadReferenceByNode(temp, &status);
           }

--- a/translators/MayaReference.cpp
+++ b/translators/MayaReference.cpp
@@ -330,8 +330,7 @@ MStatus MayaReferenceLogic::LoadMayaReference(const UsdPrim& prim, MObject& pare
                                       prim.GetPath().GetText(),
                                       referenceCommand.asChar());
   status = MGlobal::executeCommand(referenceCommand, createdNodes);
-  AL_MAYA_CHECK_ERROR(status, MString("failed to create maya reference: ") + referenceCommand
-                                      + " : " + status.errorString());
+  AL_MAYA_CHECK_ERROR(status, MString("failed to create maya reference: ") + referenceCommand);
 
   if (createdNodes.length() != 1)
   {
@@ -371,7 +370,7 @@ MStatus MayaReferenceLogic::LoadMayaReference(const UsdPrim& prim, MObject& pare
     refDependNode.setLocked(false);
     status = refDependNode.addAttribute(primNSAttr);
     refDependNode.setLocked(true);
-    AL_MAYA_CHECK_ERROR(status, MString("failed to add usdPrimPath attr to reference node: ") + status.errorString());
+    AL_MAYA_CHECK_ERROR(status, "failed to add usdPrimPath attr to reference node");
   }
   else if (status == MS::kFailure)
   {
@@ -383,9 +382,9 @@ MStatus MayaReferenceLogic::LoadMayaReference(const UsdPrim& prim, MObject& pare
   {
       MDGModifier attrMod;
       status = attrMod.newPlugValueString(MPlug(referenceObject, primNSAttr), rigNamespaceM);
-      AL_MAYA_CHECK_ERROR(status, MString("failed to set usdPrimPath attr on reference node: ") + status.errorString());
+      AL_MAYA_CHECK_ERROR(status, "failed to set usdPrimPath attr on reference node");
       status = attrMod.doIt();
-      AL_MAYA_CHECK_ERROR(status, MString("failed to execute reference attr modifier: ") + status.errorString());
+      AL_MAYA_CHECK_ERROR(status, "failed to execute reference attr modifier");
   }
 
   return MS::kSuccess;
@@ -413,7 +412,7 @@ MStatus MayaReferenceLogic::UnloadMayaReference(MObject& parent) const
         if(temp.hasFn(MFn::kReference))
         {
           MFileIO::unloadReferenceByNode(temp, &status);
-          AL_MAYA_CHECK_ERROR(status, MString("failed to unload maya reference: ") + status.errorString());
+          AL_MAYA_CHECK_ERROR(status, "failed to unload maya reference");
         }
       }
     }
@@ -445,7 +444,7 @@ MStatus MayaReferenceLogic::connectReferenceAssociatedNode(MFnDagNode& dagNode, 
   {
     MDGModifier dgMod;
     result = dgMod.connect(srcPlug, destPlug);
-    AL_MAYA_CHECK_ERROR(result, MString("failed to connect maya reference plug: ") + result.errorString());
+    AL_MAYA_CHECK_ERROR(result, "failed to connect maya reference plug");
     result = dgMod.doIt();
   }
   return result;

--- a/translators/MayaReference.cpp
+++ b/translators/MayaReference.cpp
@@ -119,7 +119,7 @@ MStatus MayaReferenceLogic::update(const UsdPrim& prim, MObject parent) const
       MPlugArray referencePlugs;
       messagePlug.connectedTo(referencePlugs, false, true);
       
-      MString result, command, filepath;
+      MString command, filepath;
 
       for(uint32_t i = 0, n = referencePlugs.length(); i < n; ++i)
       {
@@ -138,18 +138,18 @@ MStatus MayaReferenceLogic::update(const UsdPrim& prim, MObject parent) const
                                               prim.GetPath().GetText(),
                                               command.asChar(),
                                               filepath.asChar());
-          
+
           if(!rigNamespace.empty())
           {
             // check to see if the namespace has changed
-            command = MString("file -q -ns \"") + filepath + "\"";
-            MGlobal::executeCommand(command, result);
-            TF_DEBUG(ALUSDMAYA_TRANSLATORS).Msg("MayaReferenceLogic::update prim=%s execute \"%s\"=%s\n",
+            MString refNamespace = fnReference.associatedNamespace(true);
+            TF_DEBUG(ALUSDMAYA_TRANSLATORS).Msg("MayaReferenceLogic::update prim=%s, namespace was: %s\n",
                                                 prim.GetPath().GetText(),
-                                                command.asChar(),
-                                                result.asChar());
-            if(result != rigNamespace.c_str())
+                                                refNamespace.asChar());
+            if(refNamespace != rigNamespace.c_str())
             {
+              MString filepath;
+              command = MString("referenceQuery -f \"") + fnReference.name() + "\"";
               command = "file -e -ns \"";
               command += rigNamespace.c_str();
               command += "\" \"";

--- a/translators/MayaReference.h
+++ b/translators/MayaReference.h
@@ -36,7 +36,7 @@ class MayaReferenceLogic
 public:
   MStatus LoadMayaReference(const UsdPrim& prim, MObject& parent) const;
   MStatus UnloadMayaReference(MObject& parent) const;
-  MStatus update(const UsdPrim& prim, MObject parent) const;
+  MStatus update(const UsdPrim& prim, MObject parent, MObject refNode=MObject::kNullObj) const;
 
 private:
   MStatus connectReferenceAssociatedNode(MFnDagNode& dagNode, MFnReference& refNode) const;

--- a/translators/MayaReference.h
+++ b/translators/MayaReference.h
@@ -15,6 +15,7 @@
 //
 #pragma once
 
+#include "maya/MFnReference.h"
 #include "AL/usdmaya/Common.h"
 #include "AL/usdmaya/fileio/translators/TranslatorBase.h"
 
@@ -38,8 +39,12 @@ public:
   MStatus update(const UsdPrim& prim, MObject parent) const;
 
 private:
+  MStatus connectReferenceAssociatedNode(MFnDagNode& dagNode, MFnReference& refNode) const;
+
   static const TfToken m_namespaceName;
   static const TfToken m_referenceName;
+
+  static const char* const m_primNSAttr;
 };
 
 //----------------------------------------------------------------------------------------------------------------------

--- a/translators/tests/testMayaRef.py
+++ b/translators/tests/testMayaRef.py
@@ -13,13 +13,54 @@ class testTranslatorsPlugin(unittest.TestCase):
 		mc.loadPlugin('AL_USDMayaPlugin')
 
 	@classmethod
-	def tearDown(cls):
+	def tearDownClass(cls):
 		maya.standalone.uninitialize()
 
 	def testPluginIsFunctional(self):
+		mc.file(new=1, f=1)
 		mc.AL_usdmaya_ProxyShapeImport(file='./testMayaRef.usda')
 		self.assertTrue(Tf.Type.Unknown != Tf.Type.FindByName('AL::usdmaya::fileio::translators::MayaReference'))
 		self.assertTrue(len(mc.ls('cube:pCube1')))
+
+	def testRefKeepsRefEdits(self):
+		'''Tests that, even if the MayaReference is swapped for a pure-usda representation, refedits are preserved'''
+		import AL.usdmaya
+
+		mc.file(new=1, f=1)
+		mc.AL_usdmaya_ProxyShapeImport(file='./testMayaRefUnloadable.usda')
+		stage = AL.usdmaya.StageCache.Get().GetAllStages()[0]
+		topPrim = stage.GetPrimAtPath('/usd_top')
+		mayaLoadingStyle = topPrim.GetVariantSet('mayaLoadingStyle')
+
+		def assertUsingMayaReferenceVariant():
+			self.assertEqual(1, len(mc.ls('cubeNS:pCube1')))
+			self.assertFalse(stage.GetPrimAtPath('/usd_top/pCube1_usd').IsValid())
+			self.assertEqual('mayaReference', mayaLoadingStyle.GetVariantSelection())
+
+		def assertUsingUsdVariant():
+			self.assertEqual(0, len(mc.ls('cubeNS:pCube1')))
+			self.assertTrue(stage.GetPrimAtPath('/usd_top/pCube1_usd').IsValid())
+			self.assertEqual('usd', mayaLoadingStyle.GetVariantSelection())
+
+		# by default, variant should be set so that it's a maya reference
+		assertUsingMayaReferenceVariant()
+
+		# check that, by default, the cube is at 1,2,3
+		self.assertEqual(mc.getAttr('cubeNS:pCube1.translate')[0], (1.0, 2.0, 3.0))
+		# now make a ref edit
+		mc.setAttr('cubeNS:pCube1.translate', 4.0, 5.0, 6.0)
+		self.assertEqual(mc.getAttr('cubeNS:pCube1.translate')[0], (4.0, 5.0, 6.0))
+
+		# now change the variant, so the ALMayaReference isn't part of the stage anymore
+		mayaLoadingStyle.SetVariantSelection('usd')
+		# confirm that worked
+		assertUsingUsdVariant()
+
+		# now switch back...
+		mayaLoadingStyle.SetVariantSelection('mayaReference')
+		assertUsingMayaReferenceVariant()
+		# ...and then make sure that our ref edit was preserved
+		self.assertEqual(mc.getAttr('cubeNS:pCube1.translate')[0], (4.0, 5.0, 6.0))
 
 if __name__ == '__main__':
     unittest.main()

--- a/translators/tests/testMayaRef.usda
+++ b/translators/tests/testMayaRef.usda
@@ -3,5 +3,6 @@
 def ALMayaReference "mayaRefPrim"
 {
     asset mayaReference = @./cube.ma@
+    string mayaNamespace = "cube"
 }
 

--- a/translators/tests/testMayaRefUnloadable.usda
+++ b/translators/tests/testMayaRefUnloadable.usda
@@ -1,0 +1,56 @@
+#usda 1.0
+(
+    defaultPrim = "usd_top"
+    endTimeCode = 1007
+    startTimeCode = 1007
+    upAxis = "Y"
+)
+
+def Scope "usd_top_usd" (
+    active = false
+)
+{
+    def Mesh "pCube1_usd" (
+        kind = "assembly"
+    )
+    {
+        uniform bool doubleSided = 1
+        float3[] extent = [(-0.5, -0.5, -0.5), (0.5, 0.5, 0.5)]
+        int[] faceVertexCounts = [4, 4, 4, 4, 4, 4]
+        int[] faceVertexIndices = [0, 1, 3, 2, 2, 3, 5, 4, 4, 5, 7, 6, 6, 7, 1, 0, 1, 7, 5, 3, 6, 0, 2, 4]
+        point3f[] points = [(-0.5, -0.5, 0.5), (0.5, -0.5, 0.5), (-0.5, 0.5, 0.5), (0.5, 0.5, 0.5), (-0.5, 0.5, -0.5), (0.5, 0.5, -0.5), (-0.5, -0.5, -0.5), (0.5, -0.5, -0.5)]
+        color3f[] primvars:displayColor = [(0.81763764, 0.21763764, 0.21763764)]
+    }
+}
+
+def ALMayaReference "usd_top_mayaReference" (
+    active = false
+)
+{
+    string mayaNamespace = "cubeNS"
+    asset mayaReference = @./cube.ma@
+}
+
+def "usd_top" (
+    variants = {
+        string mayaLoadingStyle = "mayaReference"
+    }
+    add variantSets = "mayaLoadingStyle"
+)
+{
+    variantSet "mayaLoadingStyle" = {
+        "mayaReference" (
+            active = true
+            add references = </usd_top_mayaReference>
+        ) {
+
+        }
+        "usd" (
+            active = true
+            add references = </usd_top_usd>
+        ) {
+
+        }
+    }
+}
+


### PR DESCRIPTION
This helps to ensure that work is not lost - it is particulary helpful if you have variants which allow switching between ALMayaReferences and pure-usd representations.

For instance, suppose you have a scene with a lot of robot-ninja-tyrannosaurs fighting, in small groups.  The scene / riggs are heavy, so the animator does not want to have to have them ALL loaded in their scene at once as maya riggs... however, she wants to be able to see them all, so she knows what's visible, etc.

So, to keep his scene managable, any any given time, most of the robo-ninja-trexs are pure-usd / hydra, with say a group of 2 or 3 brought in as full maya-references at any one time.  This change ensures that they can seamlessly switch back-and-forth between the USD and maya-rigg variants, without worrying about losing work.
