### PR TITLE
ProxyShapeSelect: avoid deletion of uninitialized m_helper ptr

### DIFF
--- a/lib/AL_USDMaya/AL/usdmaya/cmds/ProxyShapeCommands.h
+++ b/lib/AL_USDMaya/AL/usdmaya/cmds/ProxyShapeCommands.h
@@ -217,6 +217,7 @@ class ProxyShapeSelect
 {
   nodes::SelectionUndoHelper* m_helper;
 public:
+  ProxyShapeSelect () : m_helper(0) {}
   ~ProxyShapeSelect() { delete m_helper; }
   AL_MAYA_DECLARE_COMMAND();
 private:


### PR DESCRIPTION
fixes a potential crash due to deletion of nullptr