### PR TITLE
adds a python wrapper for a ProxyShape

### DIFF
--- a/lib/AL_USDMaya/AL/usdmaya/module.cpp
+++ b/lib/AL_USDMaya/AL/usdmaya/module.cpp
@@ -17,4 +17,5 @@
 
 TF_WRAP_MODULE {
     TF_WRAP(StageCache);
+    TF_WRAP(ProxyShape);
 }

--- a/lib/AL_USDMaya/AL/usdmaya/nodes/ProxyShape.cpp
+++ b/lib/AL_USDMaya/AL/usdmaya/nodes/ProxyShape.cpp
@@ -729,6 +729,18 @@ void ProxyShape::onPrimResync(SdfPath primPath, const SdfPathVector& previousPri
 }
 
 //----------------------------------------------------------------------------------------------------------------------
+void ProxyShape::resync(const SdfPath& primPath)
+{
+  m_compositionHasChanged = true;
+  m_changedPath = primPath;
+  SdfPathVector outPathVector;
+  SdfPathVector changedPaths;
+
+  onPrePrimChanged(primPath, outPathVector);
+  onPrimResync(primPath, changedPaths);
+}
+
+//----------------------------------------------------------------------------------------------------------------------
 void ProxyShape::onObjectsChanged(UsdNotice::ObjectsChanged const& notice, UsdStageWeakPtr const& sender)
 {
   if(MFileIO::isOpeningFile())
@@ -950,7 +962,7 @@ void ProxyShape::variantSelectionListener(SdfNotice::LayersDidChange const& noti
                                          path.GetText());
           if(!m_compositionHasChanged)
           {
-            TF_DEBUG(ALUSDMAYA_EVALUATION).Msg("ProxyShape::Already in a composition change state. Ignoring \n");
+            TF_DEBUG(ALUSDMAYA_EVALUATION).Msg("ProxyShape::Not yet in a composition change state. Recording path. \n");
             m_changedPath = path;
           }
           m_compositionHasChanged = true;

--- a/lib/AL_USDMaya/AL/usdmaya/nodes/ProxyShape.cpp
+++ b/lib/AL_USDMaya/AL/usdmaya/nodes/ProxyShape.cpp
@@ -731,13 +731,16 @@ void ProxyShape::onPrimResync(SdfPath primPath, const SdfPathVector& previousPri
 //----------------------------------------------------------------------------------------------------------------------
 void ProxyShape::resync(const SdfPath& primPath)
 {
-  m_compositionHasChanged = true;
-  m_changedPath = primPath;
-  SdfPathVector outPathVector;
-  SdfPathVector changedPaths;
+  // FIMXE: This method was needed to call update() on all translators in the maya scene. Since then some new
+  // locking and selectability functionality has been added to onObjectsChanged(). I would want to call the logic in
+  // that method to handle this resyncing but it would need to be refactored.
 
-  onPrePrimChanged(primPath, outPathVector);
-  onPrimResync(primPath, changedPaths);
+  SdfPathVector existingSchemaPrims;
+
+  // populates list of prims from prim mapping that will change under the path to resync.
+  onPrePrimChanged(primPath, existingSchemaPrims);
+
+  onPrimResync(primPath, existingSchemaPrims);
 }
 
 //----------------------------------------------------------------------------------------------------------------------

--- a/lib/AL_USDMaya/AL/usdmaya/nodes/ProxyShape.h
+++ b/lib/AL_USDMaya/AL/usdmaya/nodes/ProxyShape.h
@@ -636,6 +636,14 @@ public:
   /// \param[in] changedPaths are child paths that existed previously and may not be existing now.
   void onPrimResync(SdfPath primPath, const SdfPathVector& changedPaths);
 
+  /// \brief Preps translators for change, and then re-ceates and updates the maya prim hierarchy below the
+  ///        specified primPath as if a variant change occurred.
+  /// \param[in] primPath of the point in the hierarchy that is potentially undergoing structural changes
+  void resync(const SdfPath& primPath);
+
+  // \brief Serialize information unique to this shape
+  void serializeThis();
+
   /// \brief This function starts the prim changed process within the proxyshape
   /// \param[in] changePath is point at which the scene is going to be modified.
   inline void primChangedAtPath(const SdfPath& changePath)

--- a/lib/AL_USDMaya/AL/usdmaya/nodes/ProxyShape.h
+++ b/lib/AL_USDMaya/AL/usdmaya/nodes/ProxyShape.h
@@ -436,8 +436,8 @@ public:
   /// \brief  will destroy all of the AL_usdmaya_Transform nodes from the prim specified, up to the root (unless any
   ///         of those transform nodes are in use by another imported prim).
   /// \param  usdPrim the leaf node in the chain of transforms we wish to remove
-  /// \param  modifier will store the changes as this path is constructed.
-  /// \param  reason  the reason why this path is being generated.
+  /// \param  modifier will store the changes as this path is removed.
+  /// \param  reason  the reason why this path is being removed.
   /// \todo   The mode ProxyShape::kSelection will cause the possibility of instability in the selection system.
   ///         This mode will be removed at a future date
   void removeUsdTransformChain(
@@ -448,8 +448,8 @@ public:
   /// \brief  will destroy all of the AL_usdmaya_Transform nodes from the prim specified, up to the root (unless any
   ///         of those transform nodes are in use by another imported prim).
   /// \param  path the leaf node in the chain of transforms we wish to remove
-  /// \param  modifier will store the changes as this path is constructed.
-  /// \param  reason  the reason why this path is being generated.
+  /// \param  modifier will store the changes as this path is removed.
+  /// \param  reason  the reason why this path is being removed.
   void removeUsdTransformChain(
       const SdfPath& path,
       MDagModifier& modifier,

--- a/lib/AL_USDMaya/AL/usdmaya/nodes/ProxyShape.h
+++ b/lib/AL_USDMaya/AL/usdmaya/nodes/ProxyShape.h
@@ -641,9 +641,6 @@ public:
   /// \param[in] primPath of the point in the hierarchy that is potentially undergoing structural changes
   void resync(const SdfPath& primPath);
 
-  // \brief Serialize information unique to this shape
-  void serializeThis();
-
   /// \brief This function starts the prim changed process within the proxyshape
   /// \param[in] changePath is point at which the scene is going to be modified.
   inline void primChangedAtPath(const SdfPath& changePath)

--- a/lib/AL_USDMaya/AL/usdmaya/nodes/wrapProxyShape.cpp
+++ b/lib/AL_USDMaya/AL/usdmaya/nodes/wrapProxyShape.cpp
@@ -1,0 +1,122 @@
+//
+// Copyright 2017 Animal Logic
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.//
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+#include "AL/usdmaya/nodes/ProxyShape.h"
+
+#include <boost/python/args.hpp>
+#include <boost/python/def.hpp>
+#include <boost/python.hpp>
+
+#include "AL/usdmaya/Utils.h"
+
+#include "maya/MFnDependencyNode.h"
+#include "maya/MSelectionList.h"
+
+#include "pxr/base/tf/pyResultConversions.h"
+
+#include <memory>
+
+//using namespace std;
+//using namespace boost::python;
+//using namespace boost;
+
+
+using AL::usdmaya::nodes::ProxyShape;
+using boost::python::reference_existing_object;
+
+namespace {
+  bool isProxyShape(MObject mobj)
+  {
+    MStatus status;
+    MFnDependencyNode mfnDep(mobj, &status);
+    if (!status)
+    {
+      return false;
+    }
+    return mfnDep.typeId() == ProxyShape::kTypeId;
+  }
+
+  ProxyShape* getProxyShapeByName(std::string name)
+  {
+    MStatus status;
+    MSelectionList sel;
+    status = sel.add(AL::usdmaya::convert(name));
+    if (!status)
+    {
+      return nullptr;
+    }
+    MDagPath dag;
+    status = sel.getDagPath(0, dag);
+    if (!status)
+    {
+      return nullptr;
+    }
+
+    MObject proxyMObj = dag.node();
+    if (!isProxyShape(proxyMObj))
+    {
+      // Try extending to shapes below...
+      if (!dag.hasFn(MFn::kTransform))
+      {
+        return nullptr;
+      }
+
+      bool foundProxy = false;
+      unsigned int numShapes;
+      if (!dag.numberOfShapesDirectlyBelow(numShapes))
+      {
+        return nullptr;
+      }
+      for (int i = 0; i < numShapes; ++i)
+      {
+        dag.extendToShapeDirectlyBelow(i);
+        if (isProxyShape(dag.node()))
+        {
+          foundProxy = true;
+          proxyMObj = dag.node();
+          break;
+        }
+        dag.pop();
+      }
+      if (!foundProxy)
+      {
+        return nullptr;
+      }
+    }
+
+    MFnDependencyNode mfnDep(proxyMObj, &status);
+    if (!status)
+    {
+      return nullptr;
+    }
+    auto proxyShapePtr = static_cast<ProxyShape*>(mfnDep.userNode(&status));
+    if (!status)
+    {
+      return nullptr;
+    }
+    return proxyShapePtr;
+  }
+}
+
+void wrapProxyShape()
+{
+  boost::python::class_<ProxyShape, boost::noncopyable>(
+      "ProxyShape", boost::python::no_init)
+    .def("getByName", getProxyShapeByName,
+        boost::python::return_value_policy<reference_existing_object>())
+        .staticmethod("getByName")
+    .def("getUsdStage", &AL::usdmaya::nodes::ProxyShape::getUsdStage)
+    ;
+}

--- a/lib/AL_USDMaya/AL/usdmaya/nodes/wrapProxyShape.cpp
+++ b/lib/AL_USDMaya/AL/usdmaya/nodes/wrapProxyShape.cpp
@@ -330,6 +330,8 @@ void wrapProxyShape()
         boost::python::return_value_policy<reference_existing_object>())
         .staticmethod("getByName")
     .def("getUsdStage", &ProxyShape::getUsdStage)
+    .def("resync", &ProxyShape::resync,
+         (boost::python::arg("path")))
     .def("boundingBox", PyProxyShape::boundingBox)
     .def("isRequiredPath", &ProxyShape::isRequiredPath)
     .def("findRequiredPath", PyProxyShape::findRequiredPath)

--- a/lib/AL_USDMaya/CMakeLists.txt
+++ b/lib/AL_USDMaya/CMakeLists.txt
@@ -237,6 +237,7 @@ add_library(${PYTHON_LIBRARY_NAME}
     SHARED
     AL/usdmaya/module.cpp
     AL/usdmaya/wrapStageCache.cpp
+    AL/usdmaya/nodes/wrapProxyShape.cpp
 )
 
 set_target_properties(${PYTHON_LIBRARY_NAME}


### PR DESCRIPTION
adds a python wrapper for a ProxyShape, which currently just has these methods:

- getByName (to construct an instance - you can't use the Class constructor)
- getUsdStage (more accurate than trying to use StageCache, particularly if you have two or more proxy shapes pointing at same USD file)
- resync
- boundingBox
- isRequiredPath
- findRequiredPath
- makeUsdTransformChain
- makeUsdTransforms
- removeUsdTransformChain
- removeUsdTransforms
- destroyTransformReferences