### PR TITLE
use Qt libraries included with maya, instead of finding system Qt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,12 +39,9 @@ add_definitions(${_PXR_CXX_DEFINITIONS})
 
 find_package(Maya REQUIRED)
 include_directories(${MAYA_INCLUDE_DIRS})
+link_directories(${MAYA_LIBRARY_DIR})
 
-if(${MAYA_API_VERSION} STRGREATER 2017)
-    find_package(Qt5Gui REQUIRED)
-else()
-    find_package(Qt4 REQUIRED QtGui)
-endif()
+# don't need to find Qt5/Qt4, as we want to just use the ones supplied by maya
 
 include_directories(${PXR_INCLUDE_DIRS})
 

--- a/lib/AL_USDMaya/AL/usdmaya/nodes/ProxyShapeUI.cpp
+++ b/lib/AL_USDMaya/AL/usdmaya/nodes/ProxyShapeUI.cpp
@@ -17,7 +17,7 @@
 #if MAYA_API_VERSION < 201700
 #include <QtGui/QApplication>
 #else
-#include <QGuiApplication>
+#include <QtGui/QGuiApplication>
 #endif
 
 #include "AL/usdmaya/DebugCodes.h"

--- a/lib/AL_USDMaya/CMakeLists.txt
+++ b/lib/AL_USDMaya/CMakeLists.txt
@@ -212,7 +212,7 @@ target_link_libraries(${LIBRARY_NAME}
 
 if(${MAYA_API_VERSION} STRGREATER 2017)
     target_link_libraries(${LIBRARY_NAME}
-        Qt5::Gui
+        Qt5Gui
     )
 else()
     target_include_directories(${LIBRARY_NAME}


### PR DESCRIPTION
Before this change, unless you had an installed (and findable, with FindQt) build of Qt that was maya-compatible, you couldn't build AL_USDMaya.  This makes it just use the binaries / headers included with maya (which we probably would prefer to link against, anyway).