### PR TITLE
add a FindUSD.cmake file

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,29 +2,18 @@
 cmake_minimum_required(VERSION 2.8.12)
 project(AL_USDMaya)
 
-# AL_USDMAYA uses pxrConfig.cmake exported targets
-# Grab USD_CONFIG_FILE either as a cmake define or an environment variable
-if(NOT USD_CONFIG_FILE)
-    if(NOT DEFINED ENV{USD_CONFIG_FILE})
-        message(FATAL_ERROR "Please set USD_CONFIG_FILE to the path to pxrConfig.cmake")
-    else()
-        set(USD_CONFIG_FILE $ENV{USD_CONFIG_FILE})
-    endif()
-endif()
-if(NOT EXISTS ${USD_CONFIG_FILE})
-    message( FATAL_ERROR "pxrConfig.cmake is needed, please set USD_CONFIG_FILE to a valid path")
-else()
-    include(${USD_CONFIG_FILE})
-endif()
-
-list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/cmake/modules")
-
 #set cmake modules - ";" separated not ":"!
 list(APPEND CMAKE_MODULE_PATH
     ${CMAKE_CURRENT_SOURCE_DIR}/cmake/defaults
     ${CMAKE_CURRENT_SOURCE_DIR}/cmake/macros
     ${CMAKE_CURRENT_SOURCE_DIR}/cmake/modules
 )
+
+# AL_USDMAYA uses pxrConfig.cmake exported targets
+# find_package(USD) can use either ${USD_ROOT}, or ${USD_CONFIG_FILE} (which should be ${USD_ROOT}/pxrConfig.cmake)
+# to find USD, defined as either Cmake var or env var
+find_package(USD REQUIRED)
+include(${USD_CONFIG_FILE})
 
 # to get PYTHON_EXECUTABLE
 find_package(PythonInterp)

--- a/cmake/modules/FindUSD.cmake
+++ b/cmake/modules/FindUSD.cmake
@@ -1,0 +1,41 @@
+# Simple module to find USD.
+
+# can use either ${USD_ROOT}, or ${USD_CONFIG_FILE} (which should be ${USD_ROOT}/pxrConfig.cmake)
+# to find USD, defined as either Cmake var or env var
+if (NOT DEFINED USD_ROOT)
+  if (DEFINED ENV{USD_ROOT})
+      set(USD_ROOT "$ENV{USD_ROOT}")
+  elseif(DEFINED USD_CONFIG_FILE)
+      get_filename_component(USD_ROOT "${USD_CONFIG_FILE}" DIRECTORY)
+  elseif(DEFINED ENV{USD_CONFIG_FILE})
+      get_filename_component(USD_ROOT "$ENV{USD_CONFIG_FILE}" DIRECTORY)
+  endif ()
+endif ()
+
+find_path(USD_INCLUDE_DIR pxr/pxr.h
+          PATHS ${USD_ROOT}/include
+          DOC "USD Include directory")
+
+find_path(USD_LIBRARY_DIR libusd.so
+          PATHS ${USD_ROOT}/lib
+          DOC "USD Librarires directory")
+
+find_file(USD_GENSCHEMA
+          names usdGenSchema
+          PATHS ${USD_ROOT}/bin
+          DOC "USD Gen schema application")
+
+find_file(USD_CONFIG_FILE
+        names pxrConfig.cmake
+        PATHS ${USD_ROOT}
+        DOC "USD cmake configuration file")
+
+include(FindPackageHandleStandardArgs)
+
+find_package_handle_standard_args(
+    USD
+    REQUIRED_VARS
+    USD_INCLUDE_DIR
+    USD_LIBRARY_DIR
+    USD_GENSCHEMA
+    USD_CONFIG_FILE)


### PR DESCRIPTION
Pretty simplistic FindUSD.cmake, but allows for slightly more standard cmake interface.  Can find USD using either ${USD_ROOT} or ${USD_CONFIG_FILE}, as either cmake var or env var.