### PR TITLE
fix for ref path check in MayaReference translator

### DIFF
--- a/translators/MayaReference.cpp
+++ b/translators/MayaReference.cpp
@@ -208,7 +208,7 @@ MStatus MayaReferenceLogic::update(const UsdPrim& prim, MObject parent, MObject 
 
       MString command, filepath;
       MFnReference fnReference(refNode);
-      command = MString("referenceQuery -f \"") + fnReference.name() + "\"";
+      command = MString("referenceQuery -f -withoutCopyNumber \"") + fnReference.name() + "\"";
       MGlobal::executeCommand(command, filepath);
       TF_DEBUG(ALUSDMAYA_TRANSLATORS).Msg("MayaReferenceLogic::update referenceNode=%s prim=%s execute \"%s\"=%s\n",
 #if MAYA_API_VERSION < 201700
@@ -229,7 +229,6 @@ MStatus MayaReferenceLogic::update(const UsdPrim& prim, MObject parent, MObject 
                                             refNamespace.asChar());
         if(refNamespace != rigNamespace.c_str())
         {
-          command = MString("referenceQuery -f \"") + fnReference.name() + "\"";
           command = "file -e -ns \"";
           command += rigNamespace.c_str();
           command += "\" \"";

--- a/translators/tests/testMayaRef.py
+++ b/translators/tests/testMayaRef.py
@@ -29,6 +29,46 @@ class testTranslatorsPlugin(unittest.TestCase):
 		self.assertEqual((3.0, 2.0, 1.0), cmds.getAttr('otherCube.translate')[0])
 		self.assertFalse(mc.getAttr('otherCube.translate', lock=1))
 
+	def testRefLoading(self):
+		'''Test that Maya References are only loaded when they need to be.'''
+		import os
+		import maya.api.OpenMaya as om
+		import AL.usdmaya
+
+		loadHistory = {}
+
+		def recordRefLoad(refNodeMobj, mFileObject, clientData):
+			'''Record when a reference path is loading.'''
+			path = mFileObject.resolvedFullName()
+			count = loadHistory.setdefault(path, 0)
+			loadHistory[path] = count + 1
+
+		id = om.MSceneMessage.addReferenceCallback(
+                       om.MSceneMessage.kBeforeLoadReference,
+                       recordRefLoad)
+
+		mc.file(new=1, f=1)
+		proxyName = mc.AL_usdmaya_ProxyShapeImport(file='./testMayaRefLoading.usda')[0]
+		proxy = AL.usdmaya.ProxyShape.getByName(proxyName)
+		refPath = os.path.abspath('./cube.ma')
+		stage = AL.usdmaya.StageCache.Get().GetAllStages()[0]
+		topPrim = stage.GetPrimAtPath('/world/optionalCube')
+		loadVariantSet = topPrim.GetVariantSet('state')
+
+		self.assertEqual(loadHistory[refPath], 2)  # one for each copy of ref
+
+		proxy.resync('/')
+		self.assertEqual(loadHistory[refPath], 2)  # refs should not have reloaded since nothing has changed.
+
+		# now change the variant, so a third ALMayaReference should load
+		loadVariantSet.SetVariantSelection('loaded')
+		self.assertEqual(loadHistory[refPath], 3)  # only the new ref should load.
+
+		loadVariantSet.SetVariantSelection('unloaded')
+		self.assertEqual(loadHistory[refPath], 3)  # ref should unload, but nothing else should load.
+
+		om.MMessage.removeCallback(id)
+
 	def testRefKeepsRefEdits(self):
 		'''Tests that, even if the MayaReference is swapped for a pure-usda representation, refedits are preserved'''
 		import AL.usdmaya

--- a/translators/tests/testMayaRefLoading.usda
+++ b/translators/tests/testMayaRefLoading.usda
@@ -1,0 +1,39 @@
+#usda 1.0
+
+def Xform "world"
+{
+    def ALMayaReference "mayaRefPrim"
+    {
+        string mayaNamespace = "cube"
+        asset mayaReference = @./cube.ma@
+    }
+
+    def ALMayaReference "otherCube"
+    {
+        string mayaNamespace = "otherNS"
+        asset mayaReference = @./cube.ma@
+        double3 xformOp:translate = (3, 2, 1)
+        uniform token[] xformOpOrder = ["xformOp:translate"]
+    }
+
+    def "optionalCube" (
+        variants = {
+            string state = "unloaded"
+        }
+        add variantSets = "state"
+    )
+    {
+        variantSet "state" = {
+            "unloaded" {
+
+            }
+            "loaded" (
+                references = </world/mayaRefPrim>
+            ) {
+                string mayaNamespace = "optionalCubeNS"
+
+            }
+        }
+    }
+}
+


### PR DESCRIPTION
This small PR fixes an issue where maya references were getting reloaded when they shouldn't be because the path check was not accounting for the reference copy number. If a file was referenced more than once and a change notification came in, all the copies would reload even if their path hadn't changed.

I've added a test that demonstrates the issue.