### PR TITLE
allow for custom pxr namespace

### DIFF
--- a/lib/AL_USDMaya/AL/usdmaya/nodes/ProxyShape.cpp
+++ b/lib/AL_USDMaya/AL/usdmaya/nodes/ProxyShape.cpp
@@ -1125,7 +1125,7 @@ void ProxyShape::loadStage()
       AL_BEGIN_PROFILE_SECTION(OpenRootLayer);
 
       // Initialise the asset resolver
-      pxr::ArGetResolver().ConfigureResolverForAsset(fileString);
+      PXR_NS::ArGetResolver().ConfigureResolverForAsset(fileString);
 
       SdfLayerRefPtr rootLayer = SdfLayer::FindOrOpen(fileString);
       AL_END_PROFILE_SECTION();


### PR DESCRIPTION
## Description (this won't be part of the changelog)
Namespace "pxr::" was hardcoded in one spot, which broke our build when we switched to using our own private USD namesapce

## Changelog
- use PXR_NS instead of "pxr" in ProxyShape.cpp
## Checklist (Please do not remove this line)
- [x] Make sure the Title and Description of the PR make sense and  provide sufficient context for your work
- [x] Do any added files have the correct AL Apache Licence Header?
- [x] Are there Doxygen comments in the headers?
- [x] Are any new features, behaviour changes documented in the .md format [documentation](https://github.com/AnimalLogic/AL_USDMaya/docs)?
- [x] Have you added, updated tests to cover new features and behaviour changes?
- [x] Have you filled out at least one changelog entry?
