### PR TITLE
fix for TEST(LayerCommands, addSubLayer)

### DIFF
--- a/plugin/AL_USDMayaTestPlugin/AL/usdmaya/commands/test_LayerCommands.cpp
+++ b/plugin/AL_USDMayaTestPlugin/AL/usdmaya/commands/test_LayerCommands.cpp
@@ -111,7 +111,7 @@ TEST(LayerCommands, addSubLayer)
   c.format(MString("AL_usdmaya_LayerCreateLayer -s -o \"^1s\" -p \"AL_usdmaya_ProxyShape1\""), testLayer);
 
   MGlobal::executeCommand(c);
-  EXPECT_EQ(proxyShape->getUsdStage()->GetLayerStack().size(), 4); // With added named layer
+  EXPECT_EQ(proxyShape->getUsdStage()->GetLayerStack().size(), 5); // With added root layer, and IT'S sublayer
 }
 
 


### PR DESCRIPTION
## Description (this won't be part of the changelog)
Fairly sure that there's a bug with the above test - the command adds a "root" layer, which itself
has a sublayer, so two more layers get added to the main layer stack when it is added... but the code only expects one new layer.  Perhaps this is a usd-0.8.3 or usd-0.8.4 change? Does this test pass for you folks with 0.8.2?

### Fixed
- fix for TEST(LayerCommands, addSubLayer) - expect command to add TWO layers to stack

## Checklist (Please do not remove this line)
- [x] Make sure the Title and Description of the PR make sense and  provide sufficient context for your work
- [x] Do any added files have the correct AL Apache Licence Header?
- [x] Are there Doxygen comments in the headers?
- [x] Are any new features, behaviour changes documented in the .md format [documentation](https://github.com/AnimalLogic/AL_USDMaya/docs)?
- [x] Have you added, updated tests to cover new features and behaviour changes?
- [x] Have you filled out at least one changelog entry?
