### PR TITLE
MayaReference: avoid error when updating a namespace on an unloaded reference

### DIFF
--- a/translators/MayaReference.cpp
+++ b/translators/MayaReference.cpp
@@ -220,30 +220,6 @@ MStatus MayaReferenceLogic::update(const UsdPrim& prim, MObject parent, MObject 
                                           command.asChar(),
                                           filepath.asChar());
 
-      if(!rigNamespace.empty())
-      {
-        // check to see if the namespace has changed
-        MString refNamespace = fnReference.associatedNamespace(true);
-        TF_DEBUG(ALUSDMAYA_TRANSLATORS).Msg("MayaReferenceLogic::update prim=%s, namespace was: %s\n",
-                                            prim.GetPath().GetText(),
-                                            refNamespace.asChar());
-        if(refNamespace != rigNamespace.c_str())
-        {
-          command = "file -e -ns \"";
-          command += rigNamespace.c_str();
-          command += "\" \"";
-          command += filepath;
-          command += "\"";
-          TF_DEBUG(ALUSDMAYA_TRANSLATORS).Msg("MayaReferenceLogic::update prim=%s execute %s\n",
-                                              prim.GetPath().GetText(),
-                                              command.asChar());
-          if(!MGlobal::executeCommand(command))
-          {
-            MGlobal::displayError(MString("Failed to update reference with new namespace. refNS:" + refNamespace + "rigNs: " + rigNamespace.c_str() + ": ") + mayaReferencePath);
-          }
-        }
-      }
-
       if(prim.IsActive())
       {
         if(mayaReferencePath.length() != 0 && filepath != mayaReferencePath)
@@ -270,6 +246,30 @@ MStatus MayaReferenceLogic::update(const UsdPrim& prim, MObject parent, MObject 
           {
             TF_DEBUG(ALUSDMAYA_TRANSLATORS).Msg("MayaReferenceLogic::update prim=%s loadReferenceByNode\n", prim.GetPath().GetText());
             MString s = MFileIO::loadReferenceByNode(refNode, &status);
+          }
+
+          if(!rigNamespace.empty())
+          {
+            // check to see if the namespace has changed
+            MString refNamespace = fnReference.associatedNamespace(true);
+            TF_DEBUG(ALUSDMAYA_TRANSLATORS).Msg("MayaReferenceLogic::update prim=%s, namespace was: %s\n",
+                                                prim.GetPath().GetText(),
+                                                refNamespace.asChar());
+            if(refNamespace != rigNamespace.c_str())
+            {
+              command = "file -e -ns \"";
+              command += rigNamespace.c_str();
+              command += "\" \"";
+              command += filepath;
+              command += "\"";
+              TF_DEBUG(ALUSDMAYA_TRANSLATORS).Msg("MayaReferenceLogic::update prim=%s execute %s\n",
+                                                  prim.GetPath().GetText(),
+                                                  command.asChar());
+              if(!MGlobal::executeCommand(command))
+              {
+                MGlobal::displayError(MString("Failed to update reference with new namespace. refNS:" + refNamespace + "rigNs: " + rigNamespace.c_str() + ": ") + mayaReferencePath);
+              }
+            }
           }
         }
       }


### PR DESCRIPTION
## Description (this won't be part of the changelog)
Instead of indiscriminately trying to update a namespace for a maya reference (which errors if the ref is unloaded), only update it if the prim is active and the reference is loaded.

### Fixed
[MayaReference translator] don't try to update a namespace on an unloaded reference

## Checklist (Please do not remove this line)
- [x] Make sure the Title and Description of the PR make sense and  provide sufficient context for your work
- [x] Do any added files have the correct AL Apache Licence Header?
- [x] Are there Doxygen comments in the headers?
- [x] Are any new features, behaviour changes documented in the .md format [documentation](https://github.com/AnimalLogic/AL_USDMaya/docs)?
- [ ] Have you added, updated tests to cover new features and behaviour changes?
- [x] Have you filled out at least one changelog entry?
