### PR TITLE
fix TranslatorContext::updatePrimTypes crash when removing non-existent prims

### DIFF
--- a/lib/AL_USDMaya/AL/usdmaya/fileio/translators/TranslatorContext.cpp
+++ b/lib/AL_USDMaya/AL/usdmaya/fileio/translators/TranslatorContext.cpp
@@ -77,7 +77,7 @@ void TranslatorContext::updatePrimTypes()
     UsdPrim prim = stage->GetPrimAtPath(path);
     if(!prim)
     {
-      m_primMapping.erase(it++);
+      it = m_primMapping.erase(it);
     }
     else
     if(it->type() != prim.GetTypeName())


### PR DESCRIPTION
## Description (this won't be part of the changelog)
When updatePrimTypes was removing prims from the m_primMapping (should
it even do that?), it wasn't using std::vector::erase correctly. As a result, it was trying to dereference invalid iterators, causing occasional crashes.

It should be noted that this only occurs if for some reason your m_primMapping has entries for prims that do not exist in the stage. When removed via a variant switch (or other tracked mechanism), the m_primMapping will be correctly updated before the updatePrimTypes call.

## Changelog
> These entries will be used to update the changelog.

> Use Markdown list syntax for each entry.

> Filled out fields will be added to the changelog.

### Fixed
[TranslatorContext] minor bug where removing previously tracked prims might cause the internal PrimLookup to become out of sync (and possibly crash).

## Checklist (Please do not remove this line)
- [x] Make sure the Title and Description of the PR make sense and  provide sufficient context for your work
- [ ] Do any added files have the correct AL Apache Licence Header?
- [ ] Are there Doxygen comments in the headers?
- [ ] Are any new features, behaviour changes documented in the .md format [documentation](https://github.com/AnimalLogic/AL_USDMaya/docs)?
- [ ] Have you added, updated tests to cover new features and behaviour changes?
- [x] Have you filled out at least one changelog entry?
