### PR TITLE
set NEED_BOOST_FILESYTEM to ON, since we're not yet building with c++17

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,8 +42,11 @@ include_directories(${PXR_INCLUDE_DIRS})
 find_package(Boost COMPONENTS
                 python
                 thread
+                filesystem
                 REQUIRED
 )
+
+set(NEED_BOOST_FILESYSTEM ON)
 
 set(CMAKE_CXX_FLAGS
     -std=c++11


### PR DESCRIPTION
## Description (this won't be part of the changelog)

Recent changes make use of boost::filesystem if we're not building with c++17... and the CMAKE still sets to use std=c++11, so we enable NEED_BOOST_FILESYTEM to avoid runtime linkage errors.

## Changelog

### Added

### Changed

### Deprecated

### Removed

### Fixed

- set NEED_BOOST_FILESYTEM to fix https://github.com/AnimalLogic/AL_USDMaya/issues/74 

## Checklist (Please do not remove this line)
- [X] Make sure the Title and Description of the PR make sense and  provide sufficient context for your work
- [X] Do any added files have the correct AL Apache Licence Header?
- [X] Are there Doxygen comments in the headers?
- [X] Are any new features, behaviour changes documented in the .md format [documentation](https://github.com/AnimalLogic/AL_USDMaya/docs)?
- [X] Have you added, updated tests to cover new features and behaviour changes?
- [X] Have you filled out at least one changelog entry?
