### PR TITLE
Layermanager now tracks all EditTargets

### DIFF
--- a/lib/AL_USDMaya/AL/usdmaya/nodes/LayerManager.h
+++ b/lib/AL_USDMaya/AL/usdmaya/nodes/LayerManager.h
@@ -63,7 +63,7 @@ public:
 
   /// \brief  Find the layer in the set of layers managed by this node, by identifier
   /// \return The found layer handle in the layer list managed by this node (invalid if not found)
-  SdfLayerHandle findLayer(std::string identifier) const;
+  SdfLayerHandle findLayer(std::string identifier, bool dirtyOnly=true) const;
 
   LayerToIdsMap::size_type size() const { return m_layerToIds.size(); }
 
@@ -148,7 +148,7 @@ public:
 
   /// \brief  Find the layer in the list of layers managed by this node, by identifier
   /// \return The found layer handle in the layer list managed by this node (invalid if not found)
-  SdfLayerHandle findLayer(std::string identifier);
+  SdfLayerHandle findLayer(std::string identifier, bool dirtyOnly=true);
 
   /// \brief  Store a list of the managed layers' identifiers in the given MStringArray
   /// \param  outputNames The array to hold the identifier names; will be cleared before being filled.

--- a/lib/AL_USDMaya/AL/usdmaya/nodes/ProxyShape.cpp
+++ b/lib/AL_USDMaya/AL/usdmaya/nodes/ProxyShape.cpp
@@ -811,40 +811,32 @@ void ProxyShape::onEditTargetChanged(UsdNotice::StageEditTargetChanged const& no
 //----------------------------------------------------------------------------------------------------------------------
 void ProxyShape::trackEditTargetLayer(LayerManager* layerManager)
 {
-  TF_DEBUG(ALUSDMAYA_LAYERS).Msg("ProxyShape::trackEditTargetLayer");
+  TF_DEBUG(ALUSDMAYA_LAYERS).Msg("ProxyShape::trackEditTargetLayer\n");
   auto stage = getUsdStage();
+
   if(!stage)
   {
     TF_DEBUG(ALUSDMAYA_LAYERS).Msg(" - no stage\n");
     return;
   }
 
-  auto prevTargetLayer = m_prevTargetLayer;
-  m_prevTargetLayer = stage->GetEditTarget().GetLayer();
+  auto currTargetLayer = stage->GetEditTarget().GetLayer();
 
-  if(!prevTargetLayer)
-  {
-    TF_DEBUG(ALUSDMAYA_LAYERS).Msg(" - no prev target layer\n");
-    return;
-  }
+  TF_DEBUG(ALUSDMAYA_LAYERS).Msg(" - curr target layer: %s\n", currTargetLayer->GetIdentifier().c_str());
 
-  TF_DEBUG(ALUSDMAYA_LAYERS).Msg(" - prev target layer: %s\n",
-      prevTargetLayer->GetIdentifier().c_str());
-  if(prevTargetLayer->IsDirty())
+  if(!layerManager)
   {
+    layerManager = LayerManager::findOrCreateManager();
+    // findOrCreateManager SHOULD always return a result, but we check anyway,
+    // to avoid any potential crash...
     if(!layerManager)
     {
-      layerManager = LayerManager::findOrCreateManager();
-      // findOrCreateManager SHOULD always return a result, but we check anyway,
-      // to avoid any potential crash...
-      if(!layerManager)
-      {
-        std::cerr << "Error creating / finding a layerManager node!" << std::endl;
-        return;
-      }
+      std::cerr << "Error creating / finding a layerManager node!" << std::endl;
+      return;
     }
-    layerManager->addLayer(prevTargetLayer);
   }
+  layerManager->addLayer(currTargetLayer);
+
   triggerEvent("EditTargetChanged");
 }
 

--- a/lib/AL_USDMaya/AL/usdmaya/nodes/ProxyShape.h
+++ b/lib/AL_USDMaya/AL/usdmaya/nodes/ProxyShape.h
@@ -982,7 +982,6 @@ private:
   fileio::translators::TranslatorManufacture m_translatorManufacture;
   SdfPath m_changedPath;
   SdfPathVector m_variantSwitchedPrims;
-  SdfLayerHandle m_prevTargetLayer;
   UsdImagingGLHdEngine* m_engine = 0;
 
   uint32_t m_engineRefCount = 0;

--- a/plugin/AL_USDMayaTestPlugin/AL/usdmaya/commands/test_LayerCommands.cpp
+++ b/plugin/AL_USDMayaTestPlugin/AL/usdmaya/commands/test_LayerCommands.cpp
@@ -79,7 +79,7 @@ TEST(LayerCommands, layerCreateLayerTests)
     // Check that we can refind the layer
     AL::usdmaya::nodes::LayerManager* layerManager = AL::usdmaya::nodes::LayerManager::findManager();
     EXPECT_TRUE(layerManager);
-    SdfLayerHandle refoundExpectedLayer = layerManager->findLayer(expectedLayer->GetIdentifier());
+    SdfLayerHandle refoundExpectedLayer = layerManager->findLayer(expectedLayer->GetIdentifier(), false);
     EXPECT_TRUE(refoundExpectedLayer);
     EXPECT_EQ(refoundExpectedLayer, expectedLayer);
   }

--- a/plugin/AL_USDMayaTestPlugin/AL/usdmaya/nodes/test_ProxyShape.cpp
+++ b/plugin/AL_USDMayaTestPlugin/AL/usdmaya/nodes/test_ProxyShape.cpp
@@ -98,9 +98,6 @@ TEST(ProxyShape, basicProxyShapeSetUp)
     // make sure path is correct
     EXPECT_EQ(temp_path, root->GetRealPath());
 
-    // before we save, the layerManager won't exist!
-    AL::usdmaya::nodes::LayerManager* layerManager = AL::usdmaya::nodes::LayerManager::findManager();
-    EXPECT_FALSE(layerManager);
 
     // UsdPrim ProxyShape::getRootPrim()
     UsdPrim rootPrim = proxy->getRootPrim();
@@ -131,14 +128,14 @@ TEST(ProxyShape, basicProxyShapeSetUp)
     EXPECT_EQ(MStatus(MS::kSuccess), MFileIO::saveAs("/tmp/AL_USDMayaTests_basicProxyShapeSetUp.ma"));
 
     // after saving, we should have a layerManager
-    layerManager = AL::usdmaya::nodes::LayerManager::findManager();
+    AL::usdmaya::nodes::LayerManager* layerManager = AL::usdmaya::nodes::LayerManager::findManager();
     ASSERT_TRUE(layerManager);
     SdfLayerHandle refoundExpectedLayer = layerManager->findLayer(session->GetIdentifier());
     EXPECT_TRUE(session->IsDirty());
     EXPECT_TRUE(refoundExpectedLayer);
     EXPECT_EQ(refoundExpectedLayer, session);
 
-    // Because root layer isn't dirty, don't expect it to be saved out
+    // Because root layer isn't dirty, don't expect it to be returned
     EXPECT_FALSE(root->IsDirty());
     refoundExpectedLayer = layerManager->findLayer(root->GetIdentifier());
     EXPECT_FALSE(refoundExpectedLayer);


### PR DESCRIPTION
## Description
@nxkb @elrond79 @sirpalee 

This is a preview of some code I modified during a task I'm part way through for some AL internal pipeline work where I need to be able to get all the layers that have been modified so I can serialise them out.

Previously, the layerManager wasn't keeping track of the first EditTarget or the last EditTarget that was set, only the previously set EditTarget. Now, if you set an EditTarget the LayerManager immediately starts to track the layer.

The LayerManager also now has the option to only return "Dirty" layers, which are layers that have changed from it's persistent(serialised?) representation. The API defaults to only return the "Dirty" layers.

Let me know if this logic breaks anything on your ends.

## Changelog

### Added

- You can now ask for all layers or just the dirty layers from the LayerManager

### Changed

- All layers that are set as the EditTarget are tracked by the LayerManager

### Deprecated

### Removed

### Fixed

## Checklist (Please do not remove this line)
- [ ] Make sure the Title and Description of the PR make sense and  provide sufficient context for your work
- [ ] Do any added files have the correct AL Apache Licence Header?
- [ ] Are there Doxygen comments in the headers?
- [ ] Are any new features, behaviour changes documented in the .md format [documentation](https://github.com/AnimalLogic/AL_USDMaya/docs)
- [ ] Have you added, updated tests to cover new features and behaviour changes
- [ ] Do all the commits in this PR have a meaningful message?
- [ ] Can ChangeLog info be extracted from the PR description or commit messages
