### PR TITLE
Removing the Qt dependency on AL_USDMaya

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,12 +28,6 @@ find_package(Maya REQUIRED)
 
 include_directories(${MAYA_INCLUDE_DIRS})
 
-if(${MAYA_API_VERSION} STRGREATER 2017)
-    find_package(Qt5Gui REQUIRED)
-else()
-    find_package(Qt4 REQUIRED QtGui)
-endif()
-
 include_directories(${PXR_INCLUDE_DIRS})
 
 # FindBoost is particularly buggy, and doesn't like custom boost locations.

--- a/docs/build.md
+++ b/docs/build.md
@@ -3,7 +3,6 @@
 ## Build Requirements
 - This project is buildable on a variety of Linux platforms (It has been tested extensively on CentOS 6.6)
 - USD-0.8.4 built with ptex-2.0.40 (<2.0.41)
-- Qt-5.6.1
 - [google test framework](https://github.com/google/googletest) (>1.8.0) to build and run the tests
 - GLEW: Maya (certainly up to 2018) uses a very old build of GLEW. We've found that both to use the latest OpenGL 4x features that Hydra exploits, and for stability reasons, you should use a newer version (e.g GLEW 2.0). We've had to LD_PRELOAD GLEW 2.0 to make this happen. 
 

--- a/doxygen/Doxyfile
+++ b/doxygen/Doxyfile
@@ -179,14 +179,6 @@ SHORT_NAMES            = NO
 
 JAVADOC_AUTOBRIEF      = NO
 
-# If the QT_AUTOBRIEF tag is set to YES then doxygen will interpret the first
-# line (until the first dot) of a Qt-style comment as the brief description. If
-# set to NO, the Qt-style will behave just like regular Qt-style comments (thus
-# requiring an explicit \brief command for a brief description.)
-# The default value is: NO.
-
-QT_AUTOBRIEF           = NO
-
 # The MULTILINE_CPP_IS_BRIEF tag can be set to YES to make doxygen treat a
 # multi-line C++ special comment block (i.e. a block of //! or /// comments) as
 # a brief description. This used to be the default behavior. The new default is
@@ -1253,69 +1245,6 @@ BINARY_TOC             = NO
 # This tag requires that the tag GENERATE_HTMLHELP is set to YES.
 
 TOC_EXPAND             = NO
-
-# If the GENERATE_QHP tag is set to YES and both QHP_NAMESPACE and
-# QHP_VIRTUAL_FOLDER are set, an additional index file will be generated that
-# can be used as input for Qt's qhelpgenerator to generate a Qt Compressed Help
-# (.qch) of the generated HTML documentation.
-# The default value is: NO.
-# This tag requires that the tag GENERATE_HTML is set to YES.
-
-GENERATE_QHP           = NO
-
-# If the QHG_LOCATION tag is specified, the QCH_FILE tag can be used to specify
-# the file name of the resulting .qch file. The path specified is relative to
-# the HTML output folder.
-# This tag requires that the tag GENERATE_QHP is set to YES.
-
-QCH_FILE               =
-
-# The QHP_NAMESPACE tag specifies the namespace to use when generating Qt Help
-# Project output. For more information please see Qt Help Project / Namespace
-# (see: http://qt-project.org/doc/qt-4.8/qthelpproject.html#namespace).
-# The default value is: org.doxygen.Project.
-# This tag requires that the tag GENERATE_QHP is set to YES.
-
-QHP_NAMESPACE          = org.doxygen.Project
-
-# The QHP_VIRTUAL_FOLDER tag specifies the namespace to use when generating Qt
-# Help Project output. For more information please see Qt Help Project / Virtual
-# Folders (see: http://qt-project.org/doc/qt-4.8/qthelpproject.html#virtual-
-# folders).
-# The default value is: doc.
-# This tag requires that the tag GENERATE_QHP is set to YES.
-
-QHP_VIRTUAL_FOLDER     = doc
-
-# If the QHP_CUST_FILTER_NAME tag is set, it specifies the name of a custom
-# filter to add. For more information please see Qt Help Project / Custom
-# Filters (see: http://qt-project.org/doc/qt-4.8/qthelpproject.html#custom-
-# filters).
-# This tag requires that the tag GENERATE_QHP is set to YES.
-
-QHP_CUST_FILTER_NAME   =
-
-# The QHP_CUST_FILTER_ATTRS tag specifies the list of the attributes of the
-# custom filter to add. For more information please see Qt Help Project / Custom
-# Filters (see: http://qt-project.org/doc/qt-4.8/qthelpproject.html#custom-
-# filters).
-# This tag requires that the tag GENERATE_QHP is set to YES.
-
-QHP_CUST_FILTER_ATTRS  =
-
-# The QHP_SECT_FILTER_ATTRS tag specifies the list of the attributes this
-# project's filter section matches. Qt Help Project / Filter Attributes (see:
-# http://qt-project.org/doc/qt-4.8/qthelpproject.html#filter-attributes).
-# This tag requires that the tag GENERATE_QHP is set to YES.
-
-QHP_SECT_FILTER_ATTRS  =
-
-# The QHG_LOCATION tag can be used to specify the location of Qt's
-# qhelpgenerator. If non-empty doxygen will try to run qhelpgenerator on the
-# generated .qhp file.
-# This tag requires that the tag GENERATE_QHP is set to YES.
-
-QHG_LOCATION           =
 
 # If the GENERATE_ECLIPSEHELP tag is set to YES, additional index files will be
 # generated, together with the HTML files, they form an Eclipse help plugin. To

--- a/lib/AL_USDMaya/AL/usdmaya/nodes/ProxyShapeUI.cpp
+++ b/lib/AL_USDMaya/AL/usdmaya/nodes/ProxyShapeUI.cpp
@@ -14,11 +14,6 @@
 // limitations under the License.
 //
 #include "maya/MTypes.h"
-#if MAYA_API_VERSION < 201700
-#include <QtGui/QApplication>
-#else
-#include <QGuiApplication>
-#endif
 
 #include "AL/usdmaya/DebugCodes.h"
 #include "AL/usdmaya/nodes/ProxyShape.h"
@@ -382,13 +377,12 @@ bool ProxyShapeUI::select(MSelectInfo& selectInfo, MSelectionList& selectionList
   {
     if(hitSelected)
     {
-#if MAYA_API_VERSION < 201700
-      Qt::KeyboardModifiers modifiers = QApplication::keyboardModifiers();
-#else
-      Qt::KeyboardModifiers modifiers = QGuiApplication::keyboardModifiers();
-#endif
-      bool shiftHeld = modifiers.testFlag(Qt::ShiftModifier);
-      bool ctrlHeld = modifiers.testFlag(Qt::ControlModifier);
+      int mods;
+      MString cmd = "getModifiers";
+      MGlobal::executeCommand(cmd, mods);
+
+      bool shiftHeld = (mods % 2);
+      bool ctrlHeld = (mods / 4 % 2);
       MGlobal::ListAdjustment mode = MGlobal::kReplaceList;
       if(shiftHeld && ctrlHeld)
         mode = MGlobal::kAddToList;
@@ -435,13 +429,12 @@ bool ProxyShapeUI::select(MSelectInfo& selectInfo, MSelectionList& selectionList
   }
   else
   {
-#if MAYA_API_VERSION < 201700
-    Qt::KeyboardModifiers modifiers = QApplication::keyboardModifiers();
-#else
-    Qt::KeyboardModifiers modifiers = QGuiApplication::keyboardModifiers();
-#endif
-    bool shiftHeld = modifiers.testFlag(Qt::ShiftModifier);
-    bool ctrlHeld = modifiers.testFlag(Qt::ControlModifier);
+    int mods;
+    MString cmd = "getModifiers";
+    MGlobal::executeCommand(cmd, mods);
+    
+    bool shiftHeld = (mods % 2);
+    bool ctrlHeld = (mods / 4 % 2);
     MGlobal::ListAdjustment mode = MGlobal::kReplaceList;
     if(shiftHeld && ctrlHeld)
       mode = MGlobal::kAddToList;

--- a/lib/AL_USDMaya/CMakeLists.txt
+++ b/lib/AL_USDMaya/CMakeLists.txt
@@ -201,21 +201,6 @@ if(NEED_BOOST_FILESYSTEM)
                         ${Boost_FILESYSTEM_LIBRARY})
 endif()
 
-
-if(${MAYA_API_VERSION} STRGREATER 2017)
-    target_link_libraries(${LIBRARY_NAME}
-        Qt5::Gui
-    )
-else()
-    target_include_directories(${LIBRARY_NAME}
-        PUBLIC
-        $ENV{MAYA_LOCATION}/include/Qt
-    )
-    target_link_libraries(${LIBRARY_NAME}
-        ${QT_QTGUI_LIBRARY}
-    )
-endif()
-
 install(TARGETS ${LIBRARY_NAME}
     LIBRARY
     DESTINATION ${CMAKE_INSTALL_PREFIX}/lib

--- a/lib/AL_USDMaya/Doxyfile
+++ b/lib/AL_USDMaya/Doxyfile
@@ -139,14 +139,6 @@ SHORT_NAMES            = NO
 
 JAVADOC_AUTOBRIEF      = NO
 
-# If the QT_AUTOBRIEF tag is set to YES then Doxygen will
-# interpret the first line (until the first dot) of a Qt-style
-# comment as the brief description. If set to NO, the comments
-# will behave just like regular Qt-style comments (thus requiring
-# an explicit \brief command for a brief description.)
-
-QT_AUTOBRIEF           = NO
-
 # The MULTILINE_CPP_IS_BRIEF tag can be set to YES to make Doxygen
 # treat a multi-line C++ special comment block (i.e. a block of //! or ///
 # comments) as a brief description. This used to be the default behaviour.
@@ -884,55 +876,6 @@ BINARY_TOC             = NO
 # to the contents of the HTML help documentation and to the tree view.
 
 TOC_EXPAND             = NO
-
-# If the GENERATE_QHP tag is set to YES and both QHP_NAMESPACE and QHP_VIRTUAL_FOLDER
-# are set, an additional index file will be generated that can be used as input for
-# Qt's qhelpgenerator to generate a Qt Compressed Help (.qch) of the generated
-# HTML documentation.
-
-GENERATE_QHP           = NO
-
-# If the QHG_LOCATION tag is specified, the QCH_FILE tag can
-# be used to specify the file name of the resulting .qch file.
-# The path specified is relative to the HTML output folder.
-
-QCH_FILE               =
-
-# The QHP_NAMESPACE tag specifies the namespace to use when generating
-# Qt Help Project output. For more information please see
-# http://doc.trolltech.com/qthelpproject.html#namespace
-
-QHP_NAMESPACE          =
-
-# The QHP_VIRTUAL_FOLDER tag specifies the namespace to use when generating
-# Qt Help Project output. For more information please see
-# http://doc.trolltech.com/qthelpproject.html#virtual-folders
-
-QHP_VIRTUAL_FOLDER     = doc
-
-# If QHP_CUST_FILTER_NAME is set, it specifies the name of a custom filter to add.
-# For more information please see
-# http://doc.trolltech.com/qthelpproject.html#custom-filters
-
-QHP_CUST_FILTER_NAME   =
-
-# The QHP_CUST_FILT_ATTRS tag specifies the list of the attributes of the custom filter to add.For more information please see
-# <a href="http://doc.trolltech.com/qthelpproject.html#custom-filters">Qt Help Project / Custom Filters</a>.
-
-QHP_CUST_FILTER_ATTRS  =
-
-# The QHP_SECT_FILTER_ATTRS tag specifies the list of the attributes this project's
-# filter section matches.
-# <a href="http://doc.trolltech.com/qthelpproject.html#filter-attributes">Qt Help Project / Filter Attributes</a>.
-
-QHP_SECT_FILTER_ATTRS  =
-
-# If the GENERATE_QHP tag is set to YES, the QHG_LOCATION tag can
-# be used to specify the location of Qt's qhelpgenerator.
-# If non-empty doxygen will try to run qhelpgenerator on the generated
-# .qhp file.
-
-QHG_LOCATION           =
 
 # The DISABLE_INDEX tag can be used to turn on/off the condensed index at
 # top of each HTML page. The value NO (the default) enables the index and


### PR DESCRIPTION
## Description (this won't be part of the changelog)

This is just a cherry-pick of this commit: https://github.com/AnimalLogic/AL_USDMaya/commit/5403e64fc120d1009f7c61b42c002f5a84e74229

...since it looks like the merging of the windows branch has stalled, and we need this change to be able to build.

### Removed
-  Removing the Qt dependency on AL_USDMaya - (Retrieving the keyboard modifiers with Maya's getModifiers command)

## Checklist (Please do not remove this line)
- [X] Make sure the Title and Description of the PR make sense and  provide sufficient context for your work
- [X] Do any added files have the correct AL Apache Licence Header?
- [X] Are there Doxygen comments in the headers?
- [X] Are any new features, behaviour changes documented in the .md format [documentation](https://github.com/AnimalLogic/AL_USDMaya/docs)?
- [X] Have you added, updated tests to cover new features and behaviour changes?
- [X] Have you filled out at least one changelog entry?
