### PR TITLE
LayerManager - hide non-dirty layers

### DIFF
--- a/lib/AL_USDMaya/AL/usdmaya/nodes/LayerManager.cpp
+++ b/lib/AL_USDMaya/AL/usdmaya/nodes/LayerManager.cpp
@@ -427,7 +427,7 @@ MStatus LayerManager::populateSerialisationAttributes()
   AL_MAYA_CHECK_ERROR(status, errorString);
   {
     boost::shared_lock_guard<boost::shared_mutex> lock(m_layersMutex);
-    MArrayDataBuilder builder(&dataBlock, layers(), m_layerDatabase.size(), &status);
+    MArrayDataBuilder builder(&dataBlock, layers(), m_layerDatabase.max_size(), &status);
     AL_MAYA_CHECK_ERROR(status, errorString);
     std::string temp;
     for (const auto& layerAndIds : m_layerDatabase)

--- a/lib/AL_USDMaya/AL/usdmaya/nodes/LayerManager.h
+++ b/lib/AL_USDMaya/AL/usdmaya/nodes/LayerManager.h
@@ -21,6 +21,7 @@
 #include "maya/MPxLocatorNode.h"
 #include "AL/maya/utils/MayaHelperMacros.h"
 
+#include <iterator>
 #include <map>
 #include <set>
 #include <boost/thread.hpp>
@@ -32,8 +33,78 @@ namespace usdmaya {
 namespace nodes {
 
 //----------------------------------------------------------------------------------------------------------------------
+/// \brief  Iterator wrapper for LayerToIdsMap that hides non-dirty items
+///         Implemented as a template to define const / non-const iterator at same time
+/// \ingroup nodes
+//----------------------------------------------------------------------------------------------------------------------
+template <typename WrappedIterator>
+class DirtyOnlyIterator
+//    : public std::iterator<std::forward_iterator_tag,
+//                           typename WrappedIterator::value_type>
+{
+public:
+  typedef typename WrappedIterator::value_type value_type;
+
+  DirtyOnlyIterator(WrappedIterator it, WrappedIterator end):
+    m_iter(it),
+    m_end(end)
+  {
+    _SetToNextDirty();
+  }
+
+  DirtyOnlyIterator(const DirtyOnlyIterator& other):
+    m_iter(other.m_iter),
+    m_end(other.m_end)
+  {
+    _SetToNextDirty();
+  }
+
+  DirtyOnlyIterator& operator++() {
+    ++m_iter;
+    _SetToNextDirty();
+    return *this;
+  }
+
+  DirtyOnlyIterator operator++(int) {
+    WrappedIterator tmp(*this);
+    operator++();
+    return tmp;
+  }
+
+  bool operator==(const DirtyOnlyIterator& rhs) const {
+    // You could argue we should check m_end too,
+    // but all we really care about is whether we're pointed
+    // at the same place, and it's faster...
+    return m_iter == rhs.m_iter;
+  }
+
+  bool operator!=(const DirtyOnlyIterator& rhs) const {
+    return m_iter != rhs.m_iter;
+  }
+
+  value_type& operator*() { return *m_iter; }
+
+private:
+  void _SetToNextDirty()
+  {
+    while (m_iter != m_end && !m_iter->first->IsDirty())
+    {
+      ++m_iter;
+    }
+  }
+
+  WrappedIterator m_iter;
+  WrappedIterator m_end;
+};
+
+//----------------------------------------------------------------------------------------------------------------------
 /// \brief  Stores layers, in a way that they may be looked up by the layer ref ptr, or by identifier
 ///         Also, unlike boost::multi_index, we can have multiple identifiers per layer
+///         You can add non-dirty layers to the database, but the query operations will "hide" them -
+///         ie, iteration will skip by them, and findLayer will return an invalid ptr if it's not dirty
+///         We allow adding non-dirty items because if we want to guarantee we always have all the latest
+///         items, we need to deal with the situation where the current edit target starts out not
+///         dirty... and it's easiest to just add it then filter it if it's not dirty
 /// \ingroup nodes
 //----------------------------------------------------------------------------------------------------------------------
 class LayerDatabase {
@@ -62,20 +133,38 @@ public:
   bool removeLayer(SdfLayerRefPtr layer);
 
   /// \brief  Find the layer in the set of layers managed by this node, by identifier
-  /// \return The found layer handle in the layer list managed by this node (invalid if not found)
-  SdfLayerHandle findLayer(std::string identifier, bool dirtyOnly=true) const;
+  /// \return The found layer handle in the layer list managed by this node (invalid if not found or not dirty)
+  SdfLayerHandle findLayer(std::string identifier) const;
 
   LayerToIdsMap::size_type size() const { return m_layerToIds.size(); }
 
-  // Iterator interface
-  typedef LayerToIdsMap::iterator iterator;
-  typedef LayerToIdsMap::const_iterator const_iterator;
-  iterator begin() { return m_layerToIds.begin(); }
-  const_iterator begin() const { return m_layerToIds.cbegin(); }
-  const_iterator cbegin() const { return m_layerToIds.cbegin(); }
-  iterator end() { return m_layerToIds.end(); }
-  const_iterator end() const { return m_layerToIds.cend(); }
-  const_iterator cend() const { return m_layerToIds.cend(); }
+  // Iterator interface - skips past non-dirty items
+  typedef DirtyOnlyIterator<LayerToIdsMap::iterator> iterator;
+  typedef DirtyOnlyIterator<LayerToIdsMap::const_iterator> const_iterator;
+  iterator begin()
+  {
+    return iterator(m_layerToIds.begin(), m_layerToIds.end());
+  }
+  const_iterator begin() const
+  {
+    return const_iterator(m_layerToIds.cbegin(), m_layerToIds.cend());
+  }
+  const_iterator cbegin() const
+  {
+    return const_iterator(m_layerToIds.cbegin(), m_layerToIds.cend());
+  }
+  iterator end()
+  {
+    return iterator(m_layerToIds.end(), m_layerToIds.end());
+  }
+  const_iterator end() const
+  {
+    return const_iterator(m_layerToIds.cend(), m_layerToIds.cend());
+  }
+  const_iterator cend() const
+  {
+    return const_iterator(m_layerToIds.cend(), m_layerToIds.cend());
+  }
 
 private:
   void _addLayer(SdfLayerRefPtr layer, const std::string& identifier,
@@ -87,6 +176,7 @@ private:
 
 //----------------------------------------------------------------------------------------------------------------------
 /// \brief  The layer manager node handles serialization and deserialization of all layers used by all ProxyShapes
+///         It may temporarily contain non-dirty layers, but those will be filtered out by query operations.
 /// \ingroup nodes
 //----------------------------------------------------------------------------------------------------------------------
 class LayerManager
@@ -148,7 +238,7 @@ public:
 
   /// \brief  Find the layer in the list of layers managed by this node, by identifier
   /// \return The found layer handle in the layer list managed by this node (invalid if not found)
-  SdfLayerHandle findLayer(std::string identifier, bool dirtyOnly=true);
+  SdfLayerHandle findLayer(std::string identifier);
 
   /// \brief  Store a list of the managed layers' identifiers in the given MStringArray
   /// \param  outputNames The array to hold the identifier names; will be cleared before being filled.

--- a/lib/AL_USDMaya/AL/usdmaya/nodes/LayerManager.h
+++ b/lib/AL_USDMaya/AL/usdmaya/nodes/LayerManager.h
@@ -49,19 +49,19 @@ public:
     m_iter(it),
     m_end(end)
   {
-    _SetToNextDirty();
+    setToNextDirty();
   }
 
   DirtyOnlyIterator(const DirtyOnlyIterator& other):
     m_iter(other.m_iter),
     m_end(other.m_end)
   {
-    _SetToNextDirty();
+    setToNextDirty();
   }
 
   DirtyOnlyIterator& operator++() {
     ++m_iter;
-    _SetToNextDirty();
+    setToNextDirty
     return *this;
   }
 
@@ -85,7 +85,7 @@ public:
   value_type& operator*() { return *m_iter; }
 
 private:
-  void _SetToNextDirty()
+  void setToNextDirty()
   {
     while (m_iter != m_end && !m_iter->first->IsDirty())
     {

--- a/lib/AL_USDMaya/AL/usdmaya/nodes/LayerManager.h
+++ b/lib/AL_USDMaya/AL/usdmaya/nodes/LayerManager.h
@@ -136,7 +136,30 @@ public:
   /// \return The found layer handle in the layer list managed by this node (invalid if not found or not dirty)
   SdfLayerHandle findLayer(std::string identifier) const;
 
-  LayerToIdsMap::size_type size() const { return m_layerToIds.size(); }
+  /// Because we may have an unknown number of non-dirty member layers which we're treating
+  /// as not-existing, we can't get a size without iterating over all the layers; we can,
+  /// however, do an empty/non-empty boolean check by seeing if begin() == end(); in the
+  /// worst case, when the LayerDatabase consists of nothing but non-dirty layers, begin()
+  /// will will still end up iterating through all the layers attempting to find a
+  /// non-dirty layer to start at, but the average case should be pretty fast
+  ///
+  /// We use the safe-bool idiom to avoid nasty automatic conversions, etc
+private:
+  typedef const LayerToIdsMap LayerDatabase::*_UnspecifiedBoolType;
+public:
+  operator _UnspecifiedBoolType() const {
+    return begin() == end() ? &LayerDatabase::m_layerToIds : nullptr;
+  }
+
+  /// \brief  Upper bound for the number of non-dirty layers in this object
+  ///         This is the count of all tracked layers, dirty-and-non-dirty;
+  ///         If it is zero, it can be guaranteed that there are no dirty
+  ///         layers, but if it is non-zero, we cannot guarantee that there
+  ///         are any non-dirty layers. Use boolean conversion above to test
+  ///         that.
+  size_t max_size() const {
+    return m_layerToIds.size();
+  }
 
   // Iterator interface - skips past non-dirty items
   typedef DirtyOnlyIterator<LayerToIdsMap::iterator> iterator;

--- a/lib/AL_USDMaya/AL/usdmaya/nodes/ProxyShape.cpp
+++ b/lib/AL_USDMaya/AL/usdmaya/nodes/ProxyShape.cpp
@@ -824,20 +824,32 @@ void ProxyShape::trackEditTargetLayer(LayerManager* layerManager)
 
   TF_DEBUG(ALUSDMAYA_LAYERS).Msg(" - curr target layer: %s\n", currTargetLayer->GetIdentifier().c_str());
 
-  if(!layerManager)
+  if (m_prevEditTarget != currTargetLayer)
   {
-    layerManager = LayerManager::findOrCreateManager();
-    // findOrCreateManager SHOULD always return a result, but we check anyway,
-    // to avoid any potential crash...
     if(!layerManager)
     {
-      std::cerr << "Error creating / finding a layerManager node!" << std::endl;
-      return;
+      layerManager = LayerManager::findOrCreateManager();
+      // findOrCreateManager SHOULD always return a result, but we check anyway,
+      // to avoid any potential crash...
+      if(!layerManager)
+      {
+        std::cerr << "Error creating / finding a layerManager node!" << std::endl;
+        return;
+      }
     }
-  }
-  layerManager->addLayer(currTargetLayer);
 
-  triggerEvent("EditTargetChanged");
+    if (m_prevEditTarget && !m_prevEditTarget->IsDirty())
+    {
+      // If the old edit target still isn't dirty, and we're switching to a new
+      // edit target, we can remove it from the layer manager
+      layerManager->removeLayer(m_prevEditTarget);
+    }
+
+    layerManager->addLayer(currTargetLayer);
+    m_prevEditTarget = currTargetLayer;
+
+    triggerEvent("EditTargetChanged");
+  }
 }
 
 //----------------------------------------------------------------------------------------------------------------------

--- a/lib/AL_USDMaya/AL/usdmaya/nodes/ProxyShape.h
+++ b/lib/AL_USDMaya/AL/usdmaya/nodes/ProxyShape.h
@@ -982,6 +982,7 @@ private:
   fileio::translators::TranslatorManufacture m_translatorManufacture;
   SdfPath m_changedPath;
   SdfPathVector m_variantSwitchedPrims;
+  SdfLayerHandle m_prevEditTarget;
   UsdImagingGLHdEngine* m_engine = 0;
 
   uint32_t m_engineRefCount = 0;

--- a/plugin/AL_USDMayaTestPlugin/AL/usdmaya/commands/test_LayerCommands.cpp
+++ b/plugin/AL_USDMayaTestPlugin/AL/usdmaya/commands/test_LayerCommands.cpp
@@ -76,10 +76,15 @@ TEST(LayerCommands, layerCreateLayerTests)
     SdfLayerHandle expectedLayer = SdfLayer::Find(testLayer);
     EXPECT_TRUE(expectedLayer);
 
-    // Check that we can refind the layer
+    // Check that since the layer hasn't been modified, it's not in the layerManager
     AL::usdmaya::nodes::LayerManager* layerManager = AL::usdmaya::nodes::LayerManager::findManager();
     EXPECT_TRUE(layerManager);
-    SdfLayerHandle refoundExpectedLayer = layerManager->findLayer(expectedLayer->GetIdentifier(), false);
+    SdfLayerHandle refoundExpectedLayer = layerManager->findLayer(expectedLayer->GetIdentifier());
+    EXPECT_FALSE(refoundExpectedLayer);
+
+    // Then dirty it, and check that we can find it in the layerManager
+    expectedLayer->SetComment("SetLayerAsDirty");
+    refoundExpectedLayer = layerManager->findLayer(expectedLayer->GetIdentifier());
     EXPECT_TRUE(refoundExpectedLayer);
     EXPECT_EQ(refoundExpectedLayer, expectedLayer);
   }


### PR DESCRIPTION
I altered the interface to LayerDatabase so that you can add non-dirty layers to it, but they're essentially hidden - queries won't find them, and it won't return them when iterating over it's contents. However, as soon as they become dirty, they will magically show up.

Also, made it so that when the edit target is changed, if the previous edit target still isn't dirty, it is removed from the LayerManger, so we avoid cluttering it up with useless non-dirty layers; at any given point, if you have N proxy shapes in the scene, there should be at most N "hidden" non-dirty layers in the LayerManager.

### Changed
- LayerManager tracks non-dirty layers, but automatically "hides" them from queries

## Checklist (Please do not remove this line)
- [X ] Make sure the Title and Description of the PR make sense and  provide sufficient context for your work
- [ X] Do any added files have the correct AL Apache Licence Header?
- [ X] Are there Doxygen comments in the headers?
- [ X] Are any new features, behaviour changes documented in the .md format [documentation](https://github.com/AnimalLogic/AL_USDMaya/docs)?
- [ X] Have you added, updated tests to cover new features and behaviour changes?
- [ X] Have you filled out at least one changelog entry?
