### PR TITLE
Adsk contrib/windows build fixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,11 +33,19 @@ include_directories(${PXR_INCLUDE_DIRS})
 # FindBoost is particularly buggy, and doesn't like custom boost locations.
 # Adding specific components forces calls to _Boost_find_library, which
 # is the rationale for listing them here.
+set(Boost_FIND_COMPONENTS
+     python
+     thread
+     filesystem
+)
+if(WIN32)
+    list(APPEND Boost_FIND_COMPONENTS
+        chrono
+    )
+endif()
+
 find_package(Boost COMPONENTS
-                python
-                thread
-                chrono
-                filesystem
+                ${Boost_FIND_COMPONENTS}
                 REQUIRED
 )
 

--- a/cmake/modules/FindMaya.cmake
+++ b/cmake/modules/FindMaya.cmake
@@ -153,7 +153,7 @@ find_path(MAYA_LIBRARY_DIR
 list(APPEND MAYA_INCLUDE_DIRS ${MAYA_INCLUDE_DIR})
 
 find_path(MAYA_DEVKIT_INC_DIR
-       GL/glext.h
+       footPrintNode/footPrintNode.cpp
     HINTS
         "${MAYA_DEVKIT_LOCATION}"
         "${MAYA_LOCATION}"

--- a/lib/AL_USDMaya/CMakeLists.txt
+++ b/lib/AL_USDMaya/CMakeLists.txt
@@ -162,6 +162,17 @@ target_include_directories(
     ${MAYA_INCLUDE_DIRS}
 )
 
+set(Boost_LINK_LIBRARIES
+    ${Boost_PYTHON_LIBRARY}
+    ${Boost_THREAD_LIBRARY}
+)
+if(WIN32)
+    list(APPEND Boost_LINK_LIBRARIES
+        ${Boost_CHRONO_LIBRARY}
+    )
+endif()
+
+
 target_link_libraries(${LIBRARY_NAME}
     AL_EventSystem
     AL_USDMayaUtils
@@ -179,9 +190,7 @@ target_link_libraries(${LIBRARY_NAME}
     usdImaging
     usdImagingGL
     vt
-    ${Boost_PYTHON_LIBRARY}
-    ${Boost_THREAD_LIBRARY}
-    ${Boost_CHRONO_LIBRARY}
+    ${Boost_LINK_LIBRARIES}
     ${MAYA_Foundation_LIBRARY}
     ${MAYA_OpenMayaAnim_LIBRARY}
     ${MAYA_OpenMayaFX_LIBRARY}

--- a/usdutils/AL/usd/utils/CMakeLists.txt
+++ b/usdutils/AL/usd/utils/CMakeLists.txt
@@ -43,6 +43,7 @@ target_include_directories(${USDUTILS_LIBRARY_NAME}
 target_link_libraries(${USDUTILS_LIBRARY_NAME}
   gf
   usd
+  ${PYTHON_LIBRARIES}
   ${MAYA_Foundation_LIBRARY}
   ${MAYA_OpenMaya_LIBRARY}
 )


### PR DESCRIPTION
## Description (this won't be part of the changelog)
Minimal changes to fix some windows build issue. 

## Changelog
- Adding boost chrono lib only for Windows builds
- Adding Python libraries dependency to fix link error on compile
- Changing the cmake lookup file for plugins as glext.h will not be in a future devkit.

### Added

### Changed

### Deprecated

### Removed

### Fixed
- Linux build failing when looking for boost chrono lib. It is not part of the USD distributable.
- glext.h file lookup on upcoming Maya 2019 devkit failing. File is not part of the devkit anymore.
- Link error while compiling the usdutil module (Missing python27.lib). Adding Python_libraries 

## Checklist (Please do not remove this line)
- [ ] Make sure the Title and Description of the PR make sense and  provide sufficient context for your work
- [ ] Do any added files have the correct AL Apache Licence Header?
- [ ] Are there Doxygen comments in the headers?
- [ ] Are any new features, behaviour changes documented in the .md format [documentation](https://github.com/AnimalLogic/AL_USDMaya/docs)?
- [ ] Have you added, updated tests to cover new features and behaviour changes?
- [ ] Have you filled out at least one changelog entry?
