### PR TITLE
make getRenderAttris update showRender

### DIFF
--- a/lib/AL_USDMaya/AL/usdmaya/nodes/ProxyDrawOverride.cpp
+++ b/lib/AL_USDMaya/AL/usdmaya/nodes/ProxyDrawOverride.cpp
@@ -135,8 +135,6 @@ MUserData* ProxyDrawOverride::prepareForDraw(
     return NULL;
   }
 
-  data->m_params.showGuides = data->m_shape->displayGuidesPlug().asBool();
-  data->m_params.showRender = data->m_shape->displayRenderGuidesPlug().asBool();
   data->m_rootPrim = data->m_shape->getRootPrim();
   data->m_engine = engine;
 

--- a/lib/AL_USDMaya/AL/usdmaya/nodes/ProxyShape.cpp
+++ b/lib/AL_USDMaya/AL/usdmaya/nodes/ProxyShape.cpp
@@ -547,6 +547,7 @@ bool ProxyShape::getRenderAttris(void* pattribs, const MHWRender::MFrameContext&
   const float complexities[] = {1.05f, 1.15f, 1.25f, 1.35f, 1.45f, 1.55f, 1.65f, 1.75f, 1.9f}; 
   attribs.complexity = complexities[complexityPlug().asInt()];
   attribs.showGuides = displayGuidesPlug().asBool();
+  attribs.showRender = displayRenderGuidesPlug().asBool();
   return true;
 }
 


### PR DESCRIPTION
## Description (this won't be part of the changelog)

Mostly a code organization change, though it does prevent `m_params.showGuides` from being updated twice in `ProxyDrawOverride::prepareForDraw` (once by `ProxyShape::getRenderAttris`, and once in the function body).

Was motivated by some internal tweaks of mine, that needed to call `getRenderAttris`, but organizationally it makes sense that if we're updating showGuides, we should update showRender too.

## Changelog

### Changed
- make getRenderAttris update showRender, as well as showGuides

## Checklist (Please do not remove this line)
- [X] Make sure the Title and Description of the PR make sense and  provide sufficient context for your work
- [X] Do any added files have the correct AL Apache Licence Header?
- [X] Are there Doxygen comments in the headers?
- [X] Are any new features, behaviour changes documented in the .md format [documentation](https://github.com/AnimalLogic/AL_USDMaya/docs)?
- [x] Have you added, updated tests to cover new features and behaviour changes?
- [X] Have you filled out at least one changelog entry?
