### PR TITLE
convert onAttributeChanged callbacks to setInternalValue

### DIFF
--- a/lib/AL_USDMaya/AL/usdmaya/Global.cpp
+++ b/lib/AL_USDMaya/AL/usdmaya/Global.cpp
@@ -317,43 +317,9 @@ static void preFileRead(void*)
 
   if(!readDepth)
   {
-    MFnDependencyNode fn;
-    {
-      MItDependencyNodes iter(MFn::kPluginShape);
-      for(; !iter.isDone(); iter.next())
-      {
-        fn.setObject(iter.item());
-        if(fn.typeId() == nodes::ProxyShape::kTypeId)
-        {
-          nodes::ProxyShape* proxy = (nodes::ProxyShape*)fn.userNode();
-          proxy->removeAttributeChangedCallback();
-        }
-      }
-    }
-
     Global::openingFile(true);
   }
-
   ++readDepth;
-}
-
-//----------------------------------------------------------------------------------------------------------------------
-static void disableAttributeChangedCallbacks()
-{
-  MFnDependencyNode fn;
-  {
-    MItDependencyNodes iter(MFn::kPluginShape);
-    for(; !iter.isDone(); iter.next())
-    {
-      fn.setObject(iter.item());
-      if(fn.typeId() == nodes::ProxyShape::kTypeId)
-      {
-        // execute a pull on each proxy shape to ensure that each one has a valid USD stage!
-        nodes::ProxyShape* proxy = (nodes::ProxyShape*)fn.userNode();
-        proxy->removeAttributeChangedCallback();
-      }
-    }
-  }
 }
 
 //----------------------------------------------------------------------------------------------------------------------
@@ -371,7 +337,6 @@ static void postFileRead(void*)
     // missed
     readDepth++;
     oldReadDepth++;
-    disableAttributeChangedCallbacks();
   }
 
   // oldReadDepth is the value BEFORE we decremented (with fetch_sub), so should be 1
@@ -413,7 +378,6 @@ static void postFileRead(void*)
       proxy->findTaggedPrims();
       proxy->deserialiseTransformRefs();
       proxy->constructGLImagingEngine();
-      proxy->addAttributeChangedCallback();
     }
     unloadedProxies.clear();
   }

--- a/lib/AL_USDMaya/AL/usdmaya/nodes/LayerManager.cpp
+++ b/lib/AL_USDMaya/AL/usdmaya/nodes/LayerManager.cpp
@@ -114,10 +114,6 @@ namespace AL {
 namespace usdmaya {
 namespace nodes {
 
-LayerManager::~LayerManager()
-{
-}
-
 //----------------------------------------------------------------------------------------------------------------------
 bool LayerDatabase::addLayer(SdfLayerRefPtr layer, const std::string& identifier)
 {

--- a/lib/AL_USDMaya/AL/usdmaya/nodes/LayerManager.h
+++ b/lib/AL_USDMaya/AL/usdmaya/nodes/LayerManager.h
@@ -239,8 +239,6 @@ public:
   inline LayerManager()
     : MPxNode(), NodeHelper() {}
 
-  ~LayerManager();
-
   /// \brief  Find the already-existing non-referenced LayerManager node in the scene, or return a null MObject
   /// \return the found LayerManager node, or a null MObject
   AL_USDMAYA_PUBLIC

--- a/lib/AL_USDMaya/AL/usdmaya/nodes/ProxyShape.cpp
+++ b/lib/AL_USDMaya/AL/usdmaya/nodes/ProxyShape.cpp
@@ -713,9 +713,7 @@ ProxyShape::~ProxyShape()
 {
   TF_DEBUG(ALUSDMAYA_EVALUATION).Msg("ProxyShape::~ProxyShape\n");
   triggerEvent("PreDestroyProxyShape");
-  MNodeMessage::removeCallback(m_attributeChanged);
   MEventMessage::removeCallback(m_onSelectionChanged);
-  removeAttributeChangedCallback();
   TfNotice::Revoke(m_variantChangedNoticeKey);
   TfNotice::Revoke(m_objectsChangedNoticeKey);
   TfNotice::Revoke(m_editTargetChanged);
@@ -766,10 +764,11 @@ MStatus ProxyShape::initialise()
     m_sessionLayerName = addStringAttr("sessionLayerName", "sln", kCached|kReadable|kWritable|kStorable|kHidden);
 
     m_serializedArCtx = addStringAttr("serializedArCtx", "arcd", kCached|kReadable|kWritable|kStorable|kHidden);
-    m_filePath = addFilePathAttr("filePath", "fp", kCached | kReadable | kWritable | kStorable | kAffectsAppearance, kLoad, "USD Files (*.usd*) (*.usd*);;Alembic Files (*.abc)");
+    // m_filePath / m_primPath / m_excludePrimPaths are internal just so we get notification on change
+    m_filePath = addFilePathAttr("filePath", "fp", kCached | kReadable | kWritable | kStorable | kAffectsAppearance | kInternal, kLoad, "USD Files (*.usd*) (*.usd*);;Alembic Files (*.abc)");
 
-    m_primPath = addStringAttr("primPath", "pp", kCached | kReadable | kWritable | kStorable | kAffectsAppearance);
-    m_excludePrimPaths = addStringAttr("excludePrimPaths", "epp", kCached | kReadable | kWritable | kStorable | kAffectsAppearance);
+    m_primPath = addStringAttr("primPath", "pp", kCached | kReadable | kWritable | kStorable | kAffectsAppearance | kInternal);
+    m_excludePrimPaths = addStringAttr("excludePrimPaths", "epp", kCached | kReadable | kWritable | kStorable | kAffectsAppearance | kInternal);
     m_populationMaskIncludePaths = addStringAttr("populationMaskIncludePaths", "pmi", kCached | kReadable | kWritable | kStorable | kAffectsAppearance);
     m_excludedTranslatedGeometry = addStringAttr("excludedTranslatedGeometry", "etg", kCached | kReadable | kWritable | kStorable | kAffectsAppearance);
 
@@ -1622,89 +1621,10 @@ void ProxyShape::constructLockPrims()
 }
 
 //----------------------------------------------------------------------------------------------------------------------
-void ProxyShape::onAttributeChanged(MNodeMessage::AttributeMessage msg, MPlug& plug, MPlug&, void* clientData)
-{
-  TF_DEBUG(ALUSDMAYA_EVALUATION).Msg("ProxyShape::onAttributeChanged\n");
-
-  const SdfPath rootPath(std::string("/"));
-  ProxyShape* proxy = (ProxyShape*)clientData;
-  if(msg & MNodeMessage::kAttributeSet)
-  {
-    // Delay stage creation if opening a file, because we haven't created the LayerManager node yet
-    if(plug == m_filePath || plug == m_assetResolverConfig)
-    {
-      if (MFileIO::isReadingFile())
-      {
-        m_unloadedProxyShapes.push_back(MObjectHandle(proxy->thisMObject()));
-      }
-      else
-      {
-        proxy->loadStage();
-      }
-    }
-    else
-    if(plug == m_primPath)
-    {
-      if(proxy->m_stage)
-      {
-        // Get the prim
-        // If no primPath string specified, then use the pseudo-root.
-        MString primPathStr = plug.asString();
-        if (primPathStr.length())
-        {
-          proxy->m_path = SdfPath(AL::maya::utils::convert(primPathStr));
-          UsdPrim prim = proxy->m_stage->GetPrimAtPath(proxy->m_path);
-          if(!prim)
-          {
-            proxy->m_path = rootPath;
-          }
-        }
-        else
-        {
-          proxy->m_path = rootPath;
-        }
-        proxy->constructGLImagingEngine();
-      }
-    }
-    else
-    if(plug == m_excludePrimPaths || plug == m_excludedTranslatedGeometry)
-    {
-      if(proxy->m_stage)
-      {
-        proxy->constructExcludedPrims();
-      }
-    }
-  }
-}
-
-//----------------------------------------------------------------------------------------------------------------------
-void ProxyShape::removeAttributeChangedCallback()
-{
-  TF_DEBUG(ALUSDMAYA_EVALUATION).Msg("ProxyShape::removeAttributeChangedCallback\n");
-  if(m_attributeChanged != 0)
-  {
-    MMessage::removeCallback(m_attributeChanged);
-    m_attributeChanged = 0;
-  }
-}
-
-//----------------------------------------------------------------------------------------------------------------------
-void ProxyShape::addAttributeChangedCallback()
-{
-  TF_DEBUG(ALUSDMAYA_EVALUATION).Msg("ProxyShape::addAttributeChangedCallback\n");
-  if(m_attributeChanged == 0)
-  {
-    MObject obj = thisMObject();
-    m_attributeChanged = MNodeMessage::addAttributeChangedCallback(obj, onAttributeChanged, (void*)this);
-  }
-}
-
-//----------------------------------------------------------------------------------------------------------------------
 void ProxyShape::postConstructor()
 {
   TF_DEBUG(ALUSDMAYA_EVALUATION).Msg("ProxyShape::postConstructor\n");
   setRenderable(true);
-  addAttributeChangedCallback();
 }
 
 //----------------------------------------------------------------------------------------------------------------------
@@ -1926,6 +1846,88 @@ MStatus ProxyShape::compute(const MPlug& plug, MDataBlock& dataBlock)
     return status == MS::kSuccess ? computeOutStageData(plug, dataBlock) : status;
   }
   return MPxSurfaceShape::compute(plug, dataBlock);
+}
+
+//----------------------------------------------------------------------------------------------------------------------
+bool ProxyShape::setInternalValue(const MPlug& plug, const MDataHandle& dataHandle)
+{
+  // We set the value in the datablock ourselves, so that the plug's value is
+  // can be queried from subfunctions (ie, loadStage, constructExcludedPrims, etc)
+  //
+  // If we simply returned "false", the "standard" implementation would set
+  // the datablock for us, but this would be too late for these subfunctions
+  TF_DEBUG(ALUSDMAYA_EVALUATION).Msg("ProxyShape::setInternalValue %s\n", plug.name().asChar());
+
+  // Delay stage creation if opening a file, because we haven't created the LayerManager node yet
+  if(plug == m_filePath || plug == m_assetResolverConfig)
+  {
+    // can't use dataHandle.datablock(), as this is a temporary datahandle
+    MDataBlock datablock = forceCache();
+    AL_MAYA_CHECK_ERROR_RETURN_VAL(outputStringValue(datablock, m_filePath, dataHandle.asString()),
+        false, "ProxyShape::setInternalValue - error setting filePath");
+
+    if (MFileIO::isReadingFile())
+    {
+      m_unloadedProxyShapes.push_back(MObjectHandle(thisMObject()));
+    }
+    else
+    {
+      loadStage();
+    }
+    return true;
+  }
+  else
+  if(plug == m_primPath)
+  {
+    // can't use dataHandle.datablock(), as this is a temporary datahandle
+    MDataBlock datablock = forceCache();
+    AL_MAYA_CHECK_ERROR_RETURN_VAL(outputStringValue(datablock, m_primPath, dataHandle.asString()),
+        false, "ProxyShape::setInternalValue - error setting primPath");
+
+    if(m_stage)
+    {
+      // Get the prim
+      // If no primPath string specified, then use the pseudo-root.
+      MString primPathStr = plug.asString();
+      if (primPathStr.length())
+      {
+        m_path = SdfPath(AL::maya::utils::convert(primPathStr));
+        UsdPrim prim = m_stage->GetPrimAtPath(m_path);
+        if(!prim)
+        {
+          m_path = SdfPath::AbsoluteRootPath();
+        }
+      }
+      else
+      {
+        m_path = SdfPath::AbsoluteRootPath();
+      }
+      constructGLImagingEngine();
+    }
+    return true;
+  }
+  else
+  if(plug == m_excludePrimPaths || plug == m_excludedTranslatedGeometry)
+  {
+    // can't use dataHandle.datablock(), as this is a temporary datahandle
+    MDataBlock datablock = forceCache();
+    AL_MAYA_CHECK_ERROR_RETURN_VAL(outputStringValue(datablock, plug.attribute(), dataHandle.asString()),
+        false, MString("ProxyShape::setInternalValue - error setting ") + plug.name());
+
+    if(m_stage)
+    {
+      constructExcludedPrims();
+    }
+    return true;
+  }
+  return false;
+}
+
+//----------------------------------------------------------------------------------------------------------------------
+bool ProxyShape::getInternalValue(const MPlug& plug, MDataHandle& dataHandle)
+{
+  // Not sure if this is needed... don't know behavior of default implementation?
+  return false;
 }
 
 //----------------------------------------------------------------------------------------------------------------------

--- a/lib/AL_USDMaya/AL/usdmaya/nodes/ProxyShape.cpp
+++ b/lib/AL_USDMaya/AL/usdmaya/nodes/ProxyShape.cpp
@@ -1888,7 +1888,7 @@ bool ProxyShape::setInternalValue(const MPlug& plug, const MDataHandle& dataHand
     {
       // Get the prim
       // If no primPath string specified, then use the pseudo-root.
-      MString primPathStr = plug.asString();
+      MString primPathStr = dataHandle.asString();
       if (primPathStr.length())
       {
         m_path = SdfPath(AL::maya::utils::convert(primPathStr));

--- a/lib/AL_USDMaya/AL/usdmaya/nodes/ProxyShape.h
+++ b/lib/AL_USDMaya/AL/usdmaya/nodes/ProxyShape.h
@@ -818,14 +818,6 @@ public:
   AL_USDMAYA_PUBLIC
   void loadStage();
 
-  /// \brief  adds the attribute changed callback to the proxy shape
-  AL_USDMAYA_PUBLIC
-  void addAttributeChangedCallback();
-
-  /// \brief  removes the attribute changed callback from the proxy shape
-  AL_USDMAYA_PUBLIC
-  void removeAttributeChangedCallback();
-
   AL_USDMAYA_PUBLIC
   void constructLockPrims();
 
@@ -988,6 +980,8 @@ private:
 
   void postConstructor() override;
   MStatus compute(const MPlug& plug, MDataBlock& dataBlock) override;
+  bool setInternalValue(const MPlug& plug, const MDataHandle& dataHandle) override;
+  bool getInternalValue(const MPlug& plug, MDataHandle& dataHandle) override;
   MStatus setDependentsDirty(const MPlug& plugBeingDirtied, MPlugArray& plugs) override;
   bool isBounded() const override;
   #if MAYA_API_VERSION < 201700
@@ -1061,8 +1055,6 @@ private:
   TfNotice::Key m_editTargetChanged;
 
   mutable std::map<UsdTimeCode, MBoundingBox> m_boundingBoxCache;
-  AL::event::CallbackId m_beforeSaveSceneId = -1;
-  MCallbackId m_attributeChanged = 0;
   MCallbackId m_onSelectionChanged = 0;
   SdfPathVector m_excludedGeometry;
   SdfPathVector m_excludedTaggedGeometry;

--- a/lib/AL_USDMaya/AL/usdmaya/nodes/RendererManager.cpp
+++ b/lib/AL_USDMaya/AL/usdmaya/nodes/RendererManager.cpp
@@ -36,11 +36,6 @@ namespace AL {
 namespace usdmaya {
 namespace nodes {
 
-RendererManager::~RendererManager()
-{
-  removeAttributeChangedCallback();
-}
-
 //----------------------------------------------------------------------------------------------------------------------
 AL_MAYA_DEFINE_NODE(RendererManager, AL_USDMAYA_RENDERERMANAGER, AL_usdmaya);
 
@@ -80,7 +75,7 @@ MStatus RendererManager::initialise()
     }
     
     m_rendererPluginName = addStringAttr(
-      "rendererPluginName", "rpn", "GL", kCached | kReadable | kWritable | kStorable | kHidden);
+      "rendererPluginName", "rpn", "GL", kInternal | kCached | kReadable | kWritable | kStorable | kHidden);
     m_rendererPlugin = addEnumAttr(
       "rendererPlugin", "rp", kInternal | kReadable | kWritable, enumNames.data(), enumValues.data()
     );
@@ -163,48 +158,8 @@ RendererManager* RendererManager::findOrCreateManager(MDGModifier* dgmod, bool* 
   return static_cast<RendererManager*>(MFnDependencyNode(findOrCreateNode(dgmod, wasCreated)).userNode());
 }
 
-
 //----------------------------------------------------------------------------------------------------------------------
-void RendererManager::onAttributeChanged(MNodeMessage::AttributeMessage msg, MPlug& plug, MPlug&, void* clientData)
-{
-  TF_DEBUG(ALUSDMAYA_RENDERER).Msg("RendererManager::onAttributeChanged\n");
-  RendererManager* manager = static_cast<RendererManager*>(clientData);
-  assert(manager);
-  if(plug == m_rendererPluginName)
-    manager->onRendererChanged();
-}
-
-//----------------------------------------------------------------------------------------------------------------------
-void RendererManager::removeAttributeChangedCallback()
-{
-  TF_DEBUG(ALUSDMAYA_RENDERER).Msg("RendererManager::removeAttributeChangedCallback\n");
-  if(m_attributeChanged != 0)
-  {
-    MMessage::removeCallback(m_attributeChanged);
-    m_attributeChanged = 0;
-  }
-}
-
-//----------------------------------------------------------------------------------------------------------------------
-void RendererManager::addAttributeChangedCallback()
-{
-  TF_DEBUG(ALUSDMAYA_RENDERER).Msg("RendererManager::addAttributeChangedCallback\n");
-  if(m_attributeChanged == 0)
-  {
-    MObject obj = thisMObject();
-    m_attributeChanged = MNodeMessage::addAttributeChangedCallback(obj, onAttributeChanged, (void*)this);
-  }
-}
-
-//----------------------------------------------------------------------------------------------------------------------
-void RendererManager::postConstructor()
-{
-  TF_DEBUG(ALUSDMAYA_RENDERER).Msg("RendererManager::postConstructor\n");
-  addAttributeChangedCallback();
-}
-
-//----------------------------------------------------------------------------------------------------------------------
-bool RendererManager::setInternalValueInContext(const MPlug& plug, const MDataHandle& dataHandle, MDGContext& ctx)
+bool RendererManager::setInternalValue(const MPlug& plug, const MDataHandle& dataHandle)
 {
   if (plug == m_rendererPlugin)
   {
@@ -216,11 +171,22 @@ bool RendererManager::setInternalValueInContext(const MPlug& plug, const MDataHa
       return true;
     }
   }
-  return MPxNode::setInternalValueInContext(plug, dataHandle, ctx);
+  else if(plug == m_rendererPluginName)
+  {
+    // can't use dataHandle.datablock(), as this is a temporary datahandle
+    // Need to set this before calling onRendererChanged, so it can access the (new) value...
+    MDataBlock datablock = forceCache();
+    AL_MAYA_CHECK_ERROR_RETURN_VAL(outputStringValue(datablock, plug.attribute(), dataHandle.asString()),
+                                   false, MString("ProxyShape::setInternalValue - error setting ") + plug.name());
+
+    onRendererChanged();
+    return true;
+  }
+  return MPxNode::setInternalValue(plug, dataHandle);
 }
 
 //----------------------------------------------------------------------------------------------------------------------
-bool RendererManager::getInternalValueInContext(const MPlug& plug, MDataHandle& dataHandle, MDGContext& ctx)
+bool RendererManager::getInternalValue(const MPlug& plug, MDataHandle& dataHandle)
 {
   if (plug == m_rendererPlugin)
   {
@@ -231,7 +197,7 @@ bool RendererManager::getInternalValueInContext(const MPlug& plug, MDataHandle& 
       return true;
     }
   }
-  return MPxNode::getInternalValueInContext(plug, dataHandle, ctx);
+  return MPxNode::getInternalValue(plug, dataHandle);
 }
 
 //----------------------------------------------------------------------------------------------------------------------

--- a/lib/AL_USDMaya/AL/usdmaya/nodes/RendererManager.h
+++ b/lib/AL_USDMaya/AL/usdmaya/nodes/RendererManager.h
@@ -50,8 +50,6 @@ public:
   inline RendererManager()
     : MPxNode(), NodeHelper() {}
 
-  ~RendererManager();
-
   /// \brief  Find the already-existing non-referenced RendererManager node in the scene, or return a null MObject
   /// \return the found RendererManager node, or a null MObject
   static MObject findNode();
@@ -111,15 +109,6 @@ public:
 
 private:
   static MObject _findNode();
-  static void onAttributeChanged(MNodeMessage::AttributeMessage, MPlug&, MPlug&, void*);
-
-  /// \brief  adds the attribute changed callback to manager
-  void addAttributeChangedCallback();
-
-  /// \brief  removes the attribute changed callback from manager
-  void removeAttributeChangedCallback();
-
-  MCallbackId m_attributeChanged = 0;
 
   static TfTokenVector m_rendererPluginsTokens;
   static MStringArray m_rendererPluginsNames;
@@ -128,11 +117,9 @@ private:
   /// MPxNode overrides
   //--------------------------------------------------------------------------------------------------------------------
 
-  void postConstructor() override;
-
-  bool setInternalValueInContext(const MPlug& plug, const MDataHandle& dataHandle, MDGContext& ctx) override;
+  bool setInternalValue(const MPlug& plug, const MDataHandle& dataHandle) override;
   
-  bool getInternalValueInContext(const MPlug& plug, MDataHandle& dataHandle, MDGContext& ctx) override;
+  bool getInternalValue(const MPlug& plug, MDataHandle& dataHandle) override;
   
 };
 


### PR DESCRIPTION
## Description (this won't be part of the changelog)

more efficient, as the onAttributeChanged callback triggers for many
situations/attributes we're not interested in

ie, the attributeChanged callback is triggered continually when tumbling in
the viewport, while setInternalValue is not

## Changelog
### Changed
- convert onAttributeChanged callbacks to setInternalValue, for performance

## Checklist (Please do not remove this line)
- [X] Make sure the Title and Description of the PR make sense and  provide sufficient context for your work
- [X] Do any added files have the correct AL Apache Licence Header?
- [X] Are there Doxygen comments in the headers?
- [X] Are any new features, behaviour changes documented in the .md format [documentation](https://github.com/AnimalLogic/AL_USDMaya/docs)?
- [X] Have you added, updated tests to cover new features and behaviour changes?
- [X] Have you filled out at least one changelog entry?
