### PR TITLE
fix for building on usd-0.8.5

### DIFF
--- a/plugin/AL_USDMayaTestPlugin/test_translators_MeshTranslator.cpp
+++ b/plugin/AL_USDMayaTestPlugin/test_translators_MeshTranslator.cpp
@@ -197,7 +197,7 @@ TEST(translators_MeshTranslator, constantUvExport)
 
     UsdGeomMesh mesh(prim);
     auto pvar = getDefaultUvSet(mesh);
-    ASSERT_TRUE(pvar);
+    ASSERT_TRUE(bool(pvar));
     EXPECT_EQ(UsdGeomTokens->constant, pvar.GetInterpolation());
 
     VtArray<GfVec2f> received;
@@ -228,7 +228,7 @@ TEST(translators_MeshTranslator, constantUvExport)
 
     UsdGeomMesh mesh(prim);
     auto pvar = getDefaultUvSet(mesh);
-    ASSERT_TRUE(pvar);
+    ASSERT_TRUE(bool(pvar));
     EXPECT_EQ(UsdGeomTokens->constant, pvar.GetInterpolation());
 
     VtArray<GfVec2f> received;
@@ -272,7 +272,7 @@ TEST(translators_MeshTranslator, vertexUvExport)
 
     UsdGeomMesh mesh(prim);
     auto pvar = getDefaultUvSet(mesh);
-    ASSERT_TRUE(pvar);
+    ASSERT_TRUE(bool(pvar));
     EXPECT_EQ(UsdGeomTokens->vertex, pvar.GetInterpolation());
 
     VtArray<GfVec2f> received;
@@ -309,7 +309,7 @@ TEST(translators_MeshTranslator, vertexUvExport)
 
     UsdGeomMesh mesh(prim);
     auto pvar = getDefaultUvSet(mesh);
-    ASSERT_TRUE(pvar);
+    ASSERT_TRUE(bool(pvar));
     EXPECT_EQ(UsdGeomTokens->vertex, pvar.GetInterpolation());
 
     VtArray<GfVec2f> received;
@@ -381,7 +381,7 @@ TEST(translators_MeshTranslator, faceVaryingUvExport)
 
     UsdGeomMesh mesh(prim);
     auto pvar = getDefaultUvSet(mesh);
-    ASSERT_TRUE(pvar);
+    ASSERT_TRUE(bool(pvar));
     EXPECT_EQ(UsdGeomTokens->faceVarying, pvar.GetInterpolation());
 
     VtArray<GfVec2f> received;
@@ -426,7 +426,7 @@ TEST(translators_MeshTranslator, faceVaryingUvExport)
 
     UsdGeomMesh mesh(prim);
     auto pvar = getDefaultUvSet(mesh);
-    ASSERT_TRUE(pvar);
+    ASSERT_TRUE(bool(pvar));
     EXPECT_EQ(UsdGeomTokens->faceVarying, pvar.GetInterpolation());
 
     VtArray<GfVec2f> received;
@@ -498,7 +498,7 @@ TEST(translators_MeshTranslator, uniformUvExport)
 
     UsdGeomMesh mesh(prim);
     auto pvar = getDefaultUvSet(mesh);
-    ASSERT_TRUE(pvar);
+    ASSERT_TRUE(bool(pvar));
     EXPECT_EQ(UsdGeomTokens->uniform, pvar.GetInterpolation());
 
     VtArray<GfVec2f> received;
@@ -536,7 +536,7 @@ TEST(translators_MeshTranslator, uniformUvExport)
 
     UsdGeomMesh mesh(prim);
     auto pvar = getDefaultUvSet(mesh);
-    ASSERT_TRUE(pvar);
+    ASSERT_TRUE(bool(pvar));
     EXPECT_EQ(UsdGeomTokens->uniform, pvar.GetInterpolation());
 
     VtArray<GfVec2f> received;
@@ -609,7 +609,7 @@ TEST(translators_MeshTranslator, constantColourExport)
 
     UsdGeomMesh mesh(prim);
     auto pvar = getDefaultColourSet(mesh);
-    ASSERT_TRUE(pvar);
+    ASSERT_TRUE(bool(pvar));
     EXPECT_EQ(UsdGeomTokens->constant, pvar.GetInterpolation());
 
     VtArray<GfVec4f> received;
@@ -644,7 +644,7 @@ TEST(translators_MeshTranslator, constantColourExport)
 
     UsdGeomMesh mesh(prim);
     auto pvar = getDefaultColourSet(mesh);
-    ASSERT_TRUE(pvar);
+    ASSERT_TRUE(bool(pvar));
     EXPECT_EQ(UsdGeomTokens->constant, pvar.GetInterpolation());
 
     VtArray<GfVec4f> received;
@@ -705,7 +705,7 @@ TEST(translators_MeshTranslator, vertexColourExport)
 
     UsdGeomMesh mesh(prim);
     auto pvar = getDefaultColourSet(mesh);
-    ASSERT_TRUE(pvar);
+    ASSERT_TRUE(bool(pvar));
     EXPECT_EQ(UsdGeomTokens->vertex, pvar.GetInterpolation());
 
     VtArray<GfVec4f> received;
@@ -744,7 +744,7 @@ TEST(translators_MeshTranslator, vertexColourExport)
 
     UsdGeomMesh mesh(prim);
     auto pvar = getDefaultColourSet(mesh);
-    ASSERT_TRUE(pvar);
+    ASSERT_TRUE(bool(pvar));
     EXPECT_EQ(UsdGeomTokens->vertex, pvar.GetInterpolation());
 
     VtArray<GfVec4f> received;
@@ -812,7 +812,7 @@ TEST(translators_MeshTranslator, uniformColourExport)
 
     UsdGeomMesh mesh(prim);
     auto pvar = getDefaultColourSet(mesh);
-    ASSERT_TRUE(pvar);
+    ASSERT_TRUE(bool(pvar));
     EXPECT_EQ(UsdGeomTokens->uniform, pvar.GetInterpolation());
 
     VtArray<GfVec4f> received;
@@ -851,7 +851,7 @@ TEST(translators_MeshTranslator, uniformColourExport)
 
     UsdGeomMesh mesh(prim);
     auto pvar = getDefaultColourSet(mesh);
-    ASSERT_TRUE(pvar);
+    ASSERT_TRUE(bool(pvar));
     EXPECT_EQ(UsdGeomTokens->uniform, pvar.GetInterpolation());
 
     VtArray<GfVec4f> received;
@@ -916,7 +916,7 @@ TEST(translators_MeshTranslator, faceVaryingColourExport)
 
     UsdGeomMesh mesh(prim);
     auto pvar = getDefaultColourSet(mesh);
-    ASSERT_TRUE(pvar);
+    ASSERT_TRUE(bool(pvar));
     EXPECT_EQ(UsdGeomTokens->faceVarying, pvar.GetInterpolation());
 
     VtArray<GfVec4f> received;
@@ -955,7 +955,7 @@ TEST(translators_MeshTranslator, faceVaryingColourExport)
 
     UsdGeomMesh mesh(prim);
     auto pvar = getDefaultColourSet(mesh);
-    ASSERT_TRUE(pvar);
+    ASSERT_TRUE(bool(pvar));
     EXPECT_EQ(UsdGeomTokens->faceVarying, pvar.GetInterpolation());
 
     VtArray<GfVec4f> received;


### PR DESCRIPTION
## Description (this won't be part of the changelog)

primvar bool conversion is explicit in usd-0.8.5

as of: 14e6a23a5b34e9e642aacfea312a39f0d4739d98

## Changelog
### Fixed
- fixed building test_translators_MeshTranslator.cpp against usd-0.8.5

## Checklist (Please do not remove this line)
- [X] Make sure the Title and Description of the PR make sense and  provide sufficient context for your work
- [X] Do any added files have the correct AL Apache Licence Header?
- [X] Are there Doxygen comments in the headers?
- [X] Are any new features, behaviour changes documented in the .md format [documentation](https://github.com/AnimalLogic/AL_USDMaya/docs)?
- [X] Have you added, updated tests to cover new features and behaviour changes?
- [X] Have you filled out at least one changelog entry?
