### PR TITLE
update the viewport for progressive renderers (like embree)

### DIFF
--- a/lib/AL_USDMaya/AL/usdmaya/nodes/ProxyDrawOverride.cpp
+++ b/lib/AL_USDMaya/AL/usdmaya/nodes/ProxyDrawOverride.cpp
@@ -59,6 +59,7 @@ public:
 //----------------------------------------------------------------------------------------------------------------------
 MString ProxyDrawOverride::kDrawDbClassification("drawdb/geometry/AL_usdmaya");
 MString ProxyDrawOverride::kDrawRegistrantId("pxrUsd");
+MUint64 ProxyDrawOverride::s_lastRefreshFrameStamp = 0;
 
 //----------------------------------------------------------------------------------------------------------------------
 ProxyDrawOverride::ProxyDrawOverride(const MObject& obj)
@@ -383,6 +384,16 @@ void ProxyDrawOverride::draw(const MHWRender::MDrawContext& context, const MUser
 
     stateManager->setDepthStencilState(previousDepthState);
     MHWRender::MStateManager::releaseDepthStencilState(depthState);
+
+    // Check framestamp b/c we don't want to put multiple refresh commands
+    // on the idle queue for a single frame-render... especially if we have
+    // multiple ProxyShapes...
+    if (!ptr->m_engine->IsConverged() && context.getFrameStamp() != s_lastRefreshFrameStamp)
+    {
+      s_lastRefreshFrameStamp = context.getFrameStamp();
+      // Force another refresh of the current viewport
+      MGlobal::executeCommandOnIdle("refresh -cv -f");
+    }
   }
   glClearColor(clearCol[0], clearCol[1], clearCol[2], clearCol[3]);
 }

--- a/lib/AL_USDMaya/AL/usdmaya/nodes/ProxyDrawOverride.h
+++ b/lib/AL_USDMaya/AL/usdmaya/nodes/ProxyDrawOverride.h
@@ -118,6 +118,9 @@ public:
   bool excludedFromPostEffects() const override
     { return false; }
 #endif
+
+private:
+  static MUint64 s_lastRefreshFrameStamp;
 };
 
 //----------------------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
## Description (this won't be part of the changelog)
Right now, if you switch the renderer (using the RendererManager node) to a progressive renderer like embree, the viewport will only show the "initial" pass, even though computation of the "converged" pass continues in the background.  The only way I've found to update the viewport is by selecting / unselecting the proxy shape.

This change makes the viewport continue to refresh, to show the refined results, until the render is converged.

## Changelog
### Added
- Viewport will continue to refresh to show updated progressive renderers (like embree) until converged


## Checklist (Please do not remove this line)
- [X] Make sure the Title and Description of the PR make sense and  provide sufficient context for your work
- [X] Do any added files have the correct AL Apache Licence Header?
- [X] Are there Doxygen comments in the headers?
- [ ] Are any new features, behaviour changes documented in the .md format [documentation](https://github.com/AnimalLogic/AL_USDMaya/docs)?
- [ ] Have you added, updated tests to cover new features and behaviour changes?
- [X] Have you filled out at least one changelog entry?
