### PR TITLE
ProxyShapeUI: add trailing newline to TF_DEBUG statements

### DIFF
--- a/lib/AL_USDMaya/AL/usdmaya/nodes/ProxyShapeUI.cpp
+++ b/lib/AL_USDMaya/AL/usdmaya/nodes/ProxyShapeUI.cpp
@@ -40,13 +40,13 @@ namespace nodes {
 //----------------------------------------------------------------------------------------------------------------------
 ProxyShapeUI::ProxyShapeUI()
 {
-  TF_DEBUG(ALUSDMAYA_DRAW).Msg("ProxyShapeUI::ProxyShapeUI");
+  TF_DEBUG(ALUSDMAYA_DRAW).Msg("ProxyShapeUI::ProxyShapeUI\n");
 }
 
 //----------------------------------------------------------------------------------------------------------------------
 ProxyShapeUI::~ProxyShapeUI()
 {
-  TF_DEBUG(ALUSDMAYA_DRAW).Msg("ProxyShapeUI::~ProxyShapeUI");
+  TF_DEBUG(ALUSDMAYA_DRAW).Msg("ProxyShapeUI::~ProxyShapeUI\n");
 }
 
 //----------------------------------------------------------------------------------------------------------------------
@@ -58,7 +58,7 @@ void* ProxyShapeUI::creator()
 //----------------------------------------------------------------------------------------------------------------------
 void ProxyShapeUI::getDrawRequests(const MDrawInfo& drawInfo, bool isObjectAndActiveOnly, MDrawRequestQueue& requests)
 {
-  TF_DEBUG(ALUSDMAYA_DRAW).Msg("ProxyShapeUI::getDrawRequests");
+  TF_DEBUG(ALUSDMAYA_DRAW).Msg("ProxyShapeUI::getDrawRequests\n");
 
   MDrawRequest request = drawInfo.getPrototype(*this);
 
@@ -79,7 +79,7 @@ void ProxyShapeUI::getDrawRequests(const MDrawInfo& drawInfo, bool isObjectAndAc
 //----------------------------------------------------------------------------------------------------------------------
 void ProxyShapeUI::draw(const MDrawRequest& request, M3dView& view) const
 {
-  TF_DEBUG(ALUSDMAYA_DRAW).Msg("ProxyShapeUI::draw");
+  TF_DEBUG(ALUSDMAYA_DRAW).Msg("ProxyShapeUI::draw\n");
 
   //
   view.beginGL();
@@ -263,7 +263,7 @@ SdfPathVector ProxyShapeSelectionHelper::m_paths;
 //----------------------------------------------------------------------------------------------------------------------
 bool ProxyShapeUI::select(MSelectInfo& selectInfo, MSelectionList& selectionList, MPointArray& worldSpaceSelectPoints) const
 {
-  TF_DEBUG(ALUSDMAYA_DRAW).Msg("ProxyShapeUI::select");
+  TF_DEBUG(ALUSDMAYA_DRAW).Msg("ProxyShapeUI::select\n");
 
   float clearCol[4];
   glGetFloatv(GL_COLOR_CLEAR_VALUE, clearCol);


### PR DESCRIPTION
## Description (this won't be part of the changelog)

Just cleans up some debug prints (that otherwise get crammed on the same line)

## Changelog
### Fixed
- Add missing newlines to some TF_DEBUG statements in ProxyShapeUI

## Checklist (Please do not remove this line)
- [X] Make sure the Title and Description of the PR make sense and  provide sufficient context for your work
- [X] Do any added files have the correct AL Apache Licence Header?
- [X] Are there Doxygen comments in the headers?
- [X] Are any new features, behaviour changes documented in the .md format [documentation](https://github.com/AnimalLogic/AL_USDMaya/docs)?
- [X] Have you added, updated tests to cover new features and behaviour changes?
- [X] Have you filled out at least one changelog entry?
