### PR TITLE
support PXR_STRICT_BUILD_MODE

### DIFF
--- a/lib/AL_USDMaya/AL/usdmaya/CodeTimings.cpp
+++ b/lib/AL_USDMaya/AL/usdmaya/CodeTimings.cpp
@@ -22,7 +22,7 @@ namespace usdmaya {
 
 //----------------------------------------------------------------------------------------------------------------------
 Profiler::ProfilerSectionStackNode Profiler::m_timeStack[MAX_TIMESTAMP_STACK_SIZE];
-int32_t Profiler::m_stackPos = 0;
+uint32_t Profiler::m_stackPos = 0;
 Profiler::ProfilerSectionPathLUT Profiler::m_map;
 
 //----------------------------------------------------------------------------------------------------------------------

--- a/lib/AL_USDMaya/AL/usdmaya/CodeTimings.h
+++ b/lib/AL_USDMaya/AL/usdmaya/CodeTimings.h
@@ -248,7 +248,7 @@ private:
   }
 
   static ProfilerSectionStackNode m_timeStack[MAX_TIMESTAMP_STACK_SIZE];
-  static int32_t m_stackPos;
+  static uint32_t m_stackPos;
   static ProfilerSectionPathLUT m_map;
 };
 

--- a/lib/AL_USDMaya/AL/usdmaya/nodes/RendererManager.cpp
+++ b/lib/AL_USDMaya/AL/usdmaya/nodes/RendererManager.cpp
@@ -272,7 +272,7 @@ void RendererManager::changeRendererPlugin(ProxyShape* proxy, bool creation)
       if (rendererId == 0 && creation)
         return;
       
-      assert(rendererId < m_rendererPluginsTokens.size());
+      assert(static_cast<size_t>(rendererId) < m_rendererPluginsTokens.size());
       TfToken plugin = m_rendererPluginsTokens[rendererId];
       if (!proxy->engine()->SetRendererPlugin(plugin))
       {

--- a/lib/AL_USDMaya/AL/usdmaya/nodes/TransformationMatrix.cpp
+++ b/lib/AL_USDMaya/AL/usdmaya/nodes/TransformationMatrix.cpp
@@ -1611,6 +1611,8 @@ void TransformationMatrix::insertRotateOp()
     break;
 
   default:
+    TF_DEBUG(ALUSDMAYA_EVALUATION).Msg("TransformationMatrix::insertRotateOp - got invalid rotation order; assuming XYZ");
+    op = m_xform.AddRotateXYZOp(UsdGeomXformOp::PrecisionFloat, TfToken("rotate"));
     break;
   }
 

--- a/usdutils/AL/usd/utils/DiffCore.cpp
+++ b/usdutils/AL/usd/utils/DiffCore.cpp
@@ -1266,7 +1266,7 @@ bool compareUvArray(
 
   const f256 eps8 = splat8f(eps);
   const size_t count8 = count & ~0x7ULL;
-  size_t i = 0, j = 0;
+  size_t i = 0;
 
   // check all values that can be processed in blocks of 4
   for(; i < count8; i += 8)

--- a/utils/AL/event/EventHandler.h
+++ b/utils/AL/event/EventHandler.h
@@ -958,7 +958,7 @@ public:
       }
 
       // register an empty event handler so that we can catch any missing events
-      EventId nullEventId = registerEvent(eventName, kUnknownEventType);
+      registerEvent(eventName, kUnknownEventType);
       eventInfo = event(eventName);
       return eventInfo->buildCallback(tag, functionPointer, weight, userData);
     }
@@ -983,7 +983,7 @@ public:
       return eventInfo->buildCallback(tag, commandText, weight, isPython);
     }
     // register an empty event handler so that we can catch any missing events
-    EventId nullEventId = registerEvent(eventName, kUnknownEventType);
+    registerEvent(eventName, kUnknownEventType);
     eventInfo = event(eventName);
     return eventInfo->buildCallback(tag, commandText, weight, isPython);
   }


### PR DESCRIPTION
## Description (this won't be part of the changelog)

this fixes up a number of compiler warnings (mostly signed/unsigned comparison,
and unused functions), so that AL_USDMaya may be used with PXR_STRICT_BUILD_MODE.

Among other things, this will enable error on issues like functions which should
have a return value, but don't.  Also, even with PXR_STRICT_BUILD_MODE, it will
make warnings stand out more.

## Changelog
### Fixed
- A number of compiler warnings fixed, so PXR_STRICT_BUILD_MODE may be used

## Checklist (Please do not remove this line)
- [X] Make sure the Title and Description of the PR make sense and  provide sufficient context for your work
- [X] Do any added files have the correct AL Apache Licence Header?
- [X] Are there Doxygen comments in the headers?
- [X] Are any new features, behaviour changes documented in the .md format [documentation](https://github.com/AnimalLogic/AL_USDMaya/docs)?
- [X] Have you added, updated tests to cover new features and behaviour changes?
- [X] Have you filled out at least one changelog entry?
