### PR TITLE
fix for duplicating proxyShapes

### DIFF
--- a/lib/AL_USDMaya/AL/usdmaya/nodes/ProxyShape.cpp
+++ b/lib/AL_USDMaya/AL/usdmaya/nodes/ProxyShape.cpp
@@ -1228,7 +1228,10 @@ void ProxyShape::loadStage()
   AL_BEGIN_PROFILE_SECTION(LoadStage);
   MDataBlock dataBlock = forceCache();
   // in case there was already a stage in m_stage, check to see if it's edit target has been altered
-  trackEditTargetLayer();
+  if (m_stage)
+  {
+    trackEditTargetLayer();
+  }
   m_stage = UsdStageRefPtr();
 
   // Get input attr values
@@ -1764,6 +1767,11 @@ MStatus ProxyShape::computeOutStageData(const MPlug& plug, MDataBlock& dataBlock
     return MS::kFailure;
   }
 
+  // make sure a stage is loaded
+  if (!m_stage)
+  {
+    loadStage();
+  }
   // Set the output stage data params
   usdStageData->stage = m_stage;
   usdStageData->primPath = m_path;


### PR DESCRIPTION
## Description (this won't be part of the changelog)
Make sure loadStage is called when a proxyShape is duplicated, so that the new shape is ready for use.

### Fixed
When you duplicate a proxy shape, you wont see anything in the viewport and it wont be fully initialize until you reopen maya or find a hack (like changing the usd path) to trigger a load stage.

## Checklist (Please do not remove this line)
- [x] Make sure the Title and Description of the PR make sense and  provide sufficient context for your work
- [x] Do any added files have the correct AL Apache Licence Header?
- [x] Are there Doxygen comments in the headers?
- [x] Are any new features, behaviour changes documented in the .md format [documentation](https://github.com/AnimalLogic/AL_USDMaya/docs)?
- [x] Have you added, updated tests to cover new features and behaviour changes?
- [x] Have you filled out at least one changelog entry?
