### PR TITLE
add proxyShape translator for layout workflow

### DIFF
--- a/lib/AL_USDMaya/AL/usdmaya/nodes/translatorProxyShape.cpp
+++ b/lib/AL_USDMaya/AL/usdmaya/nodes/translatorProxyShape.cpp
@@ -17,7 +17,7 @@
 #include "translatorProxyShape.h"
 #include "ProxyShape.h"
 
-#include "usdMaya/JobArgs.h"
+#include "usdMaya/jobArgs.h"
 #include "usdMaya/primWriterArgs.h"
 #include "usdMaya/primWriterContext.h"
 #include "usdMaya/util.h"
@@ -63,8 +63,7 @@ AL_USDMayaTranslatorProxyShape::Create(
 
   const MDagPath& currPath = args.GetMDagPath();
   const MFnDagNode proxyShapeNode(currPath);
-  AL::usdmaya::nodes::ProxyShape* proxyShape =
-          (AL::usdmaya::nodes::ProxyShape*)proxyShapeNode.userNode();
+  auto proxyShape = (AL::usdmaya::nodes::ProxyShape*)proxyShapeNode.userNode();
 
   std::string refPrimPathStr;
   MPlug usdRefPrimPathPlg = proxyShape->primPathPlug();
@@ -88,8 +87,13 @@ AL_USDMayaTranslatorProxyShape::Create(
     {
       srcPrimPath = shapeStage->GetDefaultPrim().GetPath();
     }
+    // Use custom Fn ShouldGraftValue to non-destructively copy specs.
+    // This will preserve Xform type if transform writer has already run on
+    // the prim because we are merging xform + shape.
     SdfCopySpec(shapeStage->GetSessionLayer(), srcPrimPath,
-                stage->GetRootLayer(), authorPath);
+                stage->GetRootLayer(), authorPath,
+                ShouldGraftValue,
+                ShouldGraftChildren);
   }
 
   // Guard against a situation where the prim being referenced has

--- a/lib/AL_USDMaya/AL/usdmaya/nodes/translatorProxyShape.cpp
+++ b/lib/AL_USDMaya/AL/usdmaya/nodes/translatorProxyShape.cpp
@@ -1,0 +1,163 @@
+//
+// Copyright 2017 Animal Logic
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.//
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+#include "pxr/pxr.h"
+#include "translatorProxyShape.h"
+#include "ProxyShape.h"
+
+#include "usdMaya/JobArgs.h"
+#include "usdMaya/primWriterArgs.h"
+#include "usdMaya/primWriterContext.h"
+#include "usdMaya/util.h"
+
+#include "pxr/base/tf/token.h"
+#include "pxr/usd/kind/registry.h"
+#include "pxr/usd/sdf/schema.h"
+#include "pxr/usd/sdf/types.h"
+#include "pxr/usd/sdf/copyUtils.h"
+#include "pxr/usd/usd/modelAPI.h"
+#include "pxr/usd/usdGeom/xformable.h"
+
+PXR_NAMESPACE_OPEN_SCOPE
+
+/* static */
+bool
+AL_USDMayaTranslatorProxyShape::Create(
+        const PxrUsdMayaPrimWriterArgs& args,
+        PxrUsdMayaPrimWriterContext* context)
+{
+  UsdStageRefPtr stage = context->GetUsdStage();
+  SdfPath authorPath = context->GetAuthorPath();
+  UsdTimeCode usdTime = context->GetTimeCode();
+
+  context->SetExportsGprims(false);
+  context->SetExportsReferences(true);
+  context->SetPruneChildren(true);
+
+  UsdPrim prim = stage->DefinePrim(authorPath);
+  if (!prim)
+  {
+    MString errorMsg("Failed to create prim for USD reference proxyShape at path: ");
+    errorMsg += MString(authorPath.GetText());
+    MGlobal::displayError(errorMsg);
+    return false;
+  }
+
+  // only write references when time is default
+  if (!usdTime.IsDefault())
+  {
+    return true;
+  }
+
+  const MDagPath& currPath = args.GetMDagPath();
+  const MFnDagNode proxyShapeNode(currPath);
+  AL::usdmaya::nodes::ProxyShape* proxyShape =
+          (AL::usdmaya::nodes::ProxyShape*)proxyShapeNode.userNode();
+
+  std::string refPrimPathStr;
+  MPlug usdRefPrimPathPlg = proxyShape->primPathPlug();
+  if (!usdRefPrimPathPlg.isNull())
+  {
+    refPrimPathStr = usdRefPrimPathPlg.asString().asChar();
+  }
+
+  // Get proxy shape stage and graft session layer onto exported layer.
+  // Do this before authoring anything to prim because CopySpec will
+  // replace any scene description.
+  UsdStageRefPtr shapeStage = proxyShape->usdStage();
+  if (shapeStage)
+  {
+    SdfPath srcPrimPath;
+    if (!refPrimPathStr.empty())
+    {
+      srcPrimPath = SdfPath(refPrimPathStr);
+    }
+    else
+    {
+      srcPrimPath = shapeStage->GetDefaultPrim().GetPath();
+    }
+    SdfCopySpec(shapeStage->GetSessionLayer(), srcPrimPath,
+                stage->GetRootLayer(), authorPath);
+  }
+
+  // Guard against a situation where the prim being referenced has
+  // xformOp's specified in its xformOpOrder but the reference assembly
+  // in Maya has an identity transform. We would normally skip writing out
+  // the xformOpOrder, but that isn't correct since we would inherit the
+  // xformOpOrder, which we don't want.
+  // Instead, always write out an empty xformOpOrder if the transform writer
+  // did not write out an xformOpOrder in its constructor. This guarantees
+  // that we get an identity transform as expected (instead of inheriting).
+  bool resetsXformStack;
+  UsdGeomXformable xformable(prim);
+  std::vector<UsdGeomXformOp> orderedXformOps =
+          xformable.GetOrderedXformOps(&resetsXformStack);
+  if (orderedXformOps.empty() && !resetsXformStack)
+  {
+    xformable.CreateXformOpOrderAttr().Block();
+  }
+
+  MPlug usdRefFilepathPlg = proxyShape->filePathPlug();
+  if (!usdRefFilepathPlg.isNull()){
+    UsdReferences refs = prim.GetReferences();
+    std::string refAssetPath(usdRefFilepathPlg.asString().asChar());
+
+    std::string resolvedRefPath =
+            stage->ResolveIdentifierToEditTarget(refAssetPath);
+
+    if (!resolvedRefPath.empty())
+    {
+      if (refPrimPathStr.empty())
+      {
+        refs.AddReference(refAssetPath);
+      }
+      else
+      {
+        SdfPath refPrimPath(refPrimPathStr);
+        refs.AddReference(SdfReference(refAssetPath, refPrimPath));
+      }
+    }
+    else
+    {
+      MString errorMsg("Could not resolve reference '");
+      errorMsg += refAssetPath.c_str();
+      errorMsg += "'; creating placeholder Xform for <";
+      errorMsg += authorPath.GetText();
+      errorMsg += ">";
+      MGlobal::displayWarning(errorMsg);
+      prim.SetDocumentation(std::string(errorMsg.asChar()));
+    }
+  }
+
+  bool makeInstanceable = args.GetExportRefsAsInstanceable();
+  if (makeInstanceable)
+  {
+    // When bug/128076 is addressed, the IsGroup() check will become
+    // unnecessary and obsolete.
+    // XXX This test also needs to fail if there are sub-root overs
+    // on the referenceAssembly!
+    TfToken kind;
+    UsdModelAPI(prim).GetKind(&kind);
+    if (!prim.HasAuthoredInstanceable() &&
+      !KindRegistry::GetInstance().IsA(kind, KindTokens->group))
+    {
+      prim.SetInstanceable(true);
+    }
+  }
+
+  return true;
+}
+
+PXR_NAMESPACE_CLOSE_SCOPE

--- a/lib/AL_USDMaya/AL/usdmaya/nodes/translatorProxyShape.cpp
+++ b/lib/AL_USDMaya/AL/usdmaya/nodes/translatorProxyShape.cpp
@@ -119,14 +119,22 @@ AL_USDMayaTranslatorProxyShape::Create(
 
     if (!resolvedRefPath.empty())
     {
+      // If an offset has been applied to the proxyShape, we use the values to
+      // construct the reference offset so the resulting stage will be look the
+      // same.
+      auto timeOffsetPlug = proxyShape->timeOffsetPlug();
+      auto timeScalarPlug = proxyShape->timeScalarPlug();
+      SdfLayerOffset offset(timeOffsetPlug.asMTime().as(MTime::uiUnit()),
+                            timeScalarPlug.asDouble());
+
       if (refPrimPathStr.empty())
       {
-        refs.AddReference(refAssetPath);
+        refs.AddReference(refAssetPath, offset);
       }
       else
       {
         SdfPath refPrimPath(refPrimPathStr);
-        refs.AddReference(SdfReference(refAssetPath, refPrimPath));
+        refs.AddReference(SdfReference(refAssetPath, refPrimPath, offset));
       }
     }
     else

--- a/lib/AL_USDMaya/AL/usdmaya/nodes/translatorProxyShape.cpp
+++ b/lib/AL_USDMaya/AL/usdmaya/nodes/translatorProxyShape.cpp
@@ -17,6 +17,8 @@
 #include "translatorProxyShape.h"
 #include "ProxyShape.h"
 
+#include "AL/maya/utils/Utils.h"
+
 #include "usdMaya/jobArgs.h"
 #include "usdMaya/primWriterArgs.h"
 #include "usdMaya/primWriterContext.h"
@@ -69,7 +71,7 @@ AL_USDMayaTranslatorProxyShape::Create(
   MPlug usdRefPrimPathPlg = proxyShape->primPathPlug();
   if (!usdRefPrimPathPlg.isNull())
   {
-    refPrimPathStr = usdRefPrimPathPlg.asString().asChar();
+    refPrimPathStr = AL::maya::utils::convert(usdRefPrimPathPlg.asString());
   }
 
   // Get proxy shape stage and graft session layer onto exported layer.
@@ -118,7 +120,7 @@ AL_USDMayaTranslatorProxyShape::Create(
   MPlug usdRefFilepathPlg = proxyShape->filePathPlug();
   if (!usdRefFilepathPlg.isNull()){
     UsdReferences refs = prim.GetReferences();
-    std::string refAssetPath(usdRefFilepathPlg.asString().asChar());
+    std::string refAssetPath(AL::maya::utils::convert(usdRefFilepathPlg.asString()));
 
     std::string resolvedRefPath =
             stage->ResolveIdentifierToEditTarget(refAssetPath);
@@ -151,7 +153,7 @@ AL_USDMayaTranslatorProxyShape::Create(
       errorMsg += authorPath.GetText();
       errorMsg += ">";
       MGlobal::displayWarning(errorMsg);
-      prim.SetDocumentation(std::string(errorMsg.asChar()));
+      prim.SetDocumentation(errorMsg.asChar());
     }
   }
 

--- a/lib/AL_USDMaya/AL/usdmaya/nodes/translatorProxyShape.cpp
+++ b/lib/AL_USDMaya/AL/usdmaya/nodes/translatorProxyShape.cpp
@@ -87,13 +87,15 @@ AL_USDMayaTranslatorProxyShape::Create(
     {
       srcPrimPath = shapeStage->GetDefaultPrim().GetPath();
     }
-    // Use custom Fn ShouldGraftValue to non-destructively copy specs.
-    // This will preserve Xform type if transform writer has already run on
-    // the prim because we are merging xform + shape.
-    SdfCopySpec(shapeStage->GetSessionLayer(), srcPrimPath,
-                stage->GetRootLayer(), authorPath,
-                ShouldGraftValue,
-                ShouldGraftChildren);
+    if (shapeStage->GetSessionLayer()->GetPrimAtPath(srcPrimPath)){
+      // Use custom Fn ShouldGraftValue to non-destructively copy specs.
+      // This will preserve Xform type if transform writer has already run on
+      // the prim because we are merging xform + shape.
+      SdfCopySpec(shapeStage->GetSessionLayer(), srcPrimPath,
+                  stage->GetRootLayer(), authorPath,
+                  ShouldGraftValue,
+                  ShouldGraftChildren);
+    }
   }
 
   // Guard against a situation where the prim being referenced has

--- a/lib/AL_USDMaya/AL/usdmaya/nodes/translatorProxyShape.h
+++ b/lib/AL_USDMaya/AL/usdmaya/nodes/translatorProxyShape.h
@@ -1,0 +1,42 @@
+//
+// Copyright 2017 Animal Logic
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.//
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+#ifndef AL_USDMAYA_TRANSLATORPROXYSHAPE_H
+#define AL_USDMAYA_TRANSLATORPROXYSHAPE_H
+
+#include "pxr/pxr.h"
+#include "usdMaya/api.h"
+#include "usdMaya/primWriterArgs.h"
+#include "usdMaya/primWriterContext.h"
+
+PXR_NAMESPACE_OPEN_SCOPE
+
+/// This translator works with pixar's usdExport command as opposed to the
+/// translators contained in fileio.
+struct AL_USDMayaTranslatorProxyShape {
+  /// This method generates a USD prim with a model reference
+  /// when provided args and a context that identify an
+  /// AL_usdmaya_ProxyShape node.
+  PXRUSDMAYA_API
+  static bool Create(
+          const PxrUsdMayaPrimWriterArgs &args,
+          PxrUsdMayaPrimWriterContext *context);
+};
+
+
+PXR_NAMESPACE_CLOSE_SCOPE
+
+#endif //AL_USDMAYA_TRANSLATORPROXYSHAPE_H

--- a/lib/AL_USDMaya/AL/usdmaya/nodes/translatorProxyShape.h
+++ b/lib/AL_USDMaya/AL/usdmaya/nodes/translatorProxyShape.h
@@ -32,8 +32,37 @@ struct AL_USDMayaTranslatorProxyShape {
   /// AL_usdmaya_ProxyShape node.
   PXRUSDMAYA_API
   static bool Create(
-          const PxrUsdMayaPrimWriterArgs &args,
-          PxrUsdMayaPrimWriterContext *context);
+          const PxrUsdMayaPrimWriterArgs& args,
+          PxrUsdMayaPrimWriterContext* context);
+
+  /// Return true if \p field should be copied from the spec at \p srcPath in
+  /// \p srcLayer to the spec at \p dstPath in \p dstLayer.
+  /// This version overrides the default behavior to preserve values that
+  /// already exist on dest if source does not have them (otherwise they
+  /// would be cleared).
+  static bool ShouldGraftValue(SdfSpecType specType,
+                                 const TfToken& field,
+                                 const SdfLayerHandle& srcLayer,
+                                 const SdfPath& srcPath,
+                                 bool fieldInSrc,
+                                 const SdfLayerHandle& dstLayer,
+                                 const SdfPath& dstPath,
+                                 bool fieldInDst,
+                                 boost::optional<VtValue>* valueToCopy){
+    // SdfShouldCopyValueFn copies everything by default
+    return (!fieldInDst && fieldInSrc);
+  }
+
+  static bool
+  ShouldGraftChildren(
+          const TfToken& childrenField,
+          const SdfLayerHandle& srcLayer, const SdfPath& srcPath, bool fieldInSrc,
+          const SdfLayerHandle& dstLayer, const SdfPath& dstPath, bool fieldInDst,
+          boost::optional<VtValue>* srcChildren,
+          boost::optional<VtValue>* dstChildren){
+    // SdfShouldCopyChildrenFn copies everything by default
+    return true;
+  }
 };
 
 

--- a/lib/AL_USDMaya/CMakeLists.txt
+++ b/lib/AL_USDMaya/CMakeLists.txt
@@ -109,6 +109,7 @@ list(APPEND AL_usdmaya_nodes_headers
         AL/usdmaya/nodes/RendererManager.h
         AL/usdmaya/nodes/Transform.h
         AL/usdmaya/nodes/TransformationMatrix.h
+        AL/usdmaya/nodes/translatorProxyShape.h
 )
 list(APPEND AL_usdmaya_nodes_proxy_headers
         AL/usdmaya/nodes/proxy/DrivenTransforms.h
@@ -126,6 +127,7 @@ list(APPEND AL_usdmaya_nodes_source
         AL/usdmaya/nodes/TransformationMatrix.cpp
         AL/usdmaya/nodes/proxy/DrivenTransforms.cpp
         AL/usdmaya/nodes/proxy/PrimFilter.cpp
+        AL/usdmaya/nodes/translatorProxyShape.cpp
 )
 
 list(APPEND AL_usdmaya_public_headers
@@ -144,6 +146,7 @@ add_library(${LIBRARY_NAME}
         ${AL_usdmaya_fileio_source}
         ${AL_usdmaya_fileio_translators_source}
         ${AL_usdmaya_nodes_source}
+        usdTranslator.cpp
 )
 
 target_compile_definitions(${LIBRARY_NAME}

--- a/lib/AL_USDMaya/plugInfo.json
+++ b/lib/AL_USDMaya/plugInfo.json
@@ -8,6 +8,20 @@
             },
             "Name": "AL.usdmaya",
             "Type": "python"
+        },
+        {
+            "Info": {
+                "UsdMaya": {
+                    "PrimWriter": {
+                        "mayaPlugin": "AL_USDMayaPlugin",
+                        "providesTranslator": [
+                            "AL_usdmaya_ProxyShape"
+                        ]
+                    }
+                }
+            },
+            "Name": "pxr.UsdMaya",
+            "Type": "python"
         }
     ]
 }

--- a/lib/AL_USDMaya/usdTranslator.cpp
+++ b/lib/AL_USDMaya/usdTranslator.cpp
@@ -1,0 +1,29 @@
+//
+// Copyright 2017 Animal Logic
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.//
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+#include "AL/usdmaya/nodes/translatorProxyShape.h"
+#include "usdMaya/primWriterRegistry.h"
+
+#include "pxr/pxr.h"
+
+
+PXR_NAMESPACE_OPEN_SCOPE
+
+PXRUSDMAYA_DEFINE_WRITER(AL_usdmaya_ProxyShape, args, context)
+{
+  return AL_USDMayaTranslatorProxyShape::Create(args, context);
+}
+
+PXR_NAMESPACE_CLOSE_SCOPE

--- a/plugin/AL_USDMayaTestPlugin/AL/usdmaya/nodes/test_TranslatorProxyShape.cpp
+++ b/plugin/AL_USDMayaTestPlugin/AL/usdmaya/nodes/test_TranslatorProxyShape.cpp
@@ -1,0 +1,123 @@
+//
+// Copyright 2017 Animal Logic
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.//
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+#include "pxr/pxr.h"
+#include "pxr/base/tf/token.h"
+#include "pxr/usd/usd/modelAPI.h"
+#include "maya/MTime.h"
+
+#include "AL/maya/utils/Utils.h"
+#include "test_usdmaya.h"
+#include "maya/MGlobal.h"
+#include "maya/MFileIO.h"
+#include "maya/MFnDagNode.h"
+
+TEST(UsdMayaTranslators, exportProxyShapes)
+{
+  MFileIO::newFile(true);
+
+  const std::string temp_path = buildTempPath("AL_USDMayaTests_exportProxyShape.usda");
+  const std::string sphere2_path = std::string(AL_USDMAYA_TEST_DATA) + "/sphere2.usda";
+
+  MGlobal::executeCommand(MString("createNode transform -n world;createNode transform -n geo -p world;select geo"), false, true);
+
+  MSelectionList sl;
+  MObject geoDepNode;
+  sl.add("geo");
+  sl.getDependNode(0, geoDepNode);
+  MFnDagNode geoNode(geoDepNode);
+
+  // create one proxyShape with a time offset
+  MObject proxyParent;
+  AL::usdmaya::nodes::ProxyShape* proxyShape = CreateMayaProxyShape(nullptr, sphere2_path, &proxyParent);
+  MObject proxyParentNode1 = MFnDagNode(proxyParent).parent(0);
+  geoNode.addChild(proxyParentNode1);
+  // force the stage to load
+  UsdStageRefPtr stage = proxyShape->getUsdStage();
+  ASSERT_TRUE(stage);
+
+  MTime offset;
+  offset.setUnit(MTime::uiUnit());
+  offset.setValue(40);
+  proxyShape->timeOffsetPlug().setValue(offset);
+  proxyShape->timeScalarPlug().setValue(2);
+
+  // create another proxyShape with a few session layer edits
+  AL::usdmaya::nodes::ProxyShape* proxyShape2 = CreateMayaProxyShape(nullptr, sphere2_path, &proxyParent);
+  MObject proxyParentNode2 = MFnDagNode(proxyParent).parent(0);
+  geoNode.addChild(proxyParentNode2);
+  // force the stage to load
+  UsdStageRefPtr stage2 = proxyShape2->getUsdStage();
+  ASSERT_TRUE(stage2);
+
+  SdfLayerHandle session = stage2->GetSessionLayer();
+  stage2->SetEditTarget(session);
+  std::string kExtraPrimPath = "/pExtraPrimPath";
+  std::string kSecondSpherePath = "/pSphereShape2";
+  // add a new prim
+  stage2->DefinePrim(SdfPath("/pSphere1" + kExtraPrimPath));
+  // deactivate an existing prim
+  SdfPath existingSpherePath("/pSphere1" + kSecondSpherePath);
+  ASSERT_TRUE(stage2->GetPrimAtPath(existingSpherePath));
+  stage2->DefinePrim(existingSpherePath).SetActive(false);
+
+  MGlobal::executeCommand(MString("select world;"), false, true);
+  MString exportCmd;
+  exportCmd.format(MString("usdExport -f \"^1s\""), AL::maya::utils::convert(temp_path));
+  MGlobal::executeCommand(exportCmd, true);
+
+  UsdStageRefPtr resultStage = UsdStage::Open(temp_path);
+  ASSERT_TRUE(resultStage);
+  SdfLayerHandle rootLayer = resultStage->GetRootLayer();
+
+  const std::string refPrimPath = "/world/geo/" + std::string(MFnDagNode(proxyParentNode1).name().asChar());
+  const std::string refPrimPath2 = "/world/geo/" + std::string(MFnDagNode(proxyParentNode2).name().asChar());
+  TF_DEBUG(ALUSDMAYA_TRANSLATORS).Msg("Ref Prim Path 1: " + refPrimPath + "\n");
+  TF_DEBUG(ALUSDMAYA_TRANSLATORS).Msg("Ref Prim Path 2: " + refPrimPath2 + "\n");
+  std::string text;
+  rootLayer->ExportToString(&text);
+  TF_DEBUG(ALUSDMAYA_TRANSLATORS).Msg("Resulting stage contents: \n" + text);
+
+  // Check proxyShape1
+  // make sure references were created and that they have correct offset + scale
+  SdfPrimSpecHandle refSpec = rootLayer->GetPrimAtPath(SdfPath(refPrimPath));
+  ASSERT_TRUE(refSpec);
+  ASSERT_TRUE(refSpec->HasReferences());
+  std::vector<SdfReference> refs = refSpec->GetReferenceList().GetAddedOrExplicitItems();
+  ASSERT_EQ(refs[0].GetLayerOffset(), SdfLayerOffset(40, 2));
+
+  // Check proxyShape2
+  // make sure the session layer was properly grafted on
+  UsdPrim refPrim2 = resultStage->GetPrimAtPath(SdfPath(refPrimPath2));
+  ASSERT_TRUE(refPrim2.IsValid());
+  ASSERT_EQ(refPrim2.GetTypeName(), "Xform");
+  ASSERT_EQ(refPrim2.GetSpecifier(), SdfSpecifierDef);
+
+  SdfPrimSpecHandle refSpec2 = rootLayer->GetPrimAtPath(SdfPath(refPrimPath2));
+  ASSERT_TRUE(refSpec2);
+  ASSERT_TRUE(refSpec2->HasReferences());
+  // ref root should be a defined xform on the main export layer also
+  ASSERT_EQ(refSpec2->GetTypeName(), "Xform");
+  ASSERT_EQ(refSpec2->GetSpecifier(), SdfSpecifierDef);
+
+  const std::string spherePrimPath = refPrimPath2 + std::string(kSecondSpherePath);
+  UsdPrim spherePrim = resultStage->GetPrimAtPath(SdfPath(spherePrimPath));
+  ASSERT_TRUE(spherePrim.IsValid());
+  ASSERT_FALSE(spherePrim.IsActive());
+  // check that the proper specs are being created
+  SdfPrimSpecHandle specOnExportLayer = rootLayer->GetPrimAtPath(SdfPath(spherePrimPath));
+  ASSERT_EQ(specOnExportLayer->GetSpecifier(), SdfSpecifierOver);
+
+}

--- a/plugin/AL_USDMayaTestPlugin/CMakeLists.txt
+++ b/plugin/AL_USDMayaTestPlugin/CMakeLists.txt
@@ -33,6 +33,7 @@ list(APPEND AL_maya_test_source
         AL/usdmaya/nodes/test_Transform.cpp
         AL/usdmaya/nodes/test_TransformMatrix.cpp
         AL/usdmaya/nodes/test_TranslatorContext.cpp
+        AL/usdmaya/nodes/test_TranslatorProxyShape.cpp
         AL/usdmaya/nodes/test_ProxyShapeSelectabilityDB.cpp
         AL/usdmaya/nodes/proxy/test_DrivenTransforms.cpp
         AL/usdmaya/nodes/proxy/test_PrimFilter.cpp


### PR DESCRIPTION
## Description
Registers a PrimWriter translator for the AL proxyShape in pixar's maya exporter.

This PR can be a jumping off point to discuss future layout workflows with AL_UsdMaya. It also enables AL_usdMaya to be used as an alternative to Pxr assemblies. 

The translator allows an artist to build up a set from proxyShapes loading in smaller usd files.  Each proxyShape becomes a prim with an SdfReference on the exported stage and the proxyShape's session layer is "grafted" onto the exported stage under that prim. Using a reference keeps exports light and including the specs of the session layer allows for a high amount of customization.

## Justification
### All the power of assembly nodes
While the proxyShape is great for interacting with a single stage, this workflow (like the assembly workflow) makes it easy for artists to use maya nodes to manipulate references. 
- artists can work with them like regular maya nodes:
  - easy to copy and paste
  - easy to group and reparent
- workflow:
  - artist organizes set assets into maya groups, one assembly per asset
    - creates group hierarchies
    - creates proxyShape for each asset they want to add
    - duplicates proxyShapes as needed
  - artist publishes:
    - usd export is done using pxr usdMaya export
    - each assembly generates a corresponding reference in the resulting USD file

### But with more functionality...
- proxyShape nodes can be used within maya references to make "layout" rigs (assemblies are not supported within references)
  - Rigger creates controls that place proxyShape nodes in a scene and exports a .ma rig
  - Animator/ Layout artist references the rig and uses controls to place proxyShapes for the particular shot. Having a node ensures they perform operations at the reference root.
  - They can even duplicate a node to create an extra set piece.
- The proxy shape gives you direct access to the actual usd stage, and you can place edits intended for export on the session layer
- can setup cache offsets within maya and see the results
- can export edits on child prims as overs

### Further benefits
- allows us to focus features on a **single** plugin node rather than 2 nodes in 2 separate plugins
- will work with upcoming universal front end

It could be quite some time before UFE reaches a point where a single root proxy will be viable for layout (even after the basic frontend issues are solved, the issue of reparenting a prim in USD may be a deal-breaker).  It is consistent with our strategies for other departments to store layout data natively in Maya prior to exporting to USD (e.g. transforms, asset references, and default variant selections), and use AL_usdMaya downstream as a means of reading and making targeted edits to exported USD data. There no real benefit to working natively in USD before you are using composition arcs, and often the layout artist is working close to the beginning of the pipeline so all they need access to are reference arcs which can be represented by proxyShapes.

## Implementation details for discussion
### Sanctify the Session Layer
- For this workflow to be slick out of the box, it would be good to set the edit target to the session layer on node creation. From there we can track the edit target and restore it on file open. This would ensure any modifications to the proxy shapes would be the highest opinion strength and would be easy to find and copy out on export. 
- To keep the session layer clean, another small change would be to move the prim <-> dag path mapping off of the session layer and into some other data storage.

### Minor features up next
- [x] fix duplication pr #98 (merged!)
- [x] add support to use the proxyShape's time offset + scale to set the values on the created references
- [x] #100 add support for providing unresolved paths on proxyShapes (i.e. uri://asset.usd)
- [x] #102 sanctify session layer

## Changelog
### Added
- UsdMaya translator for AL_usdmaya_ProxyShape

## Checklist (Please do not remove this line)
- [x] Make sure the Title and Description of the PR make sense and  provide sufficient context for your work
- [x] Do any added files have the correct AL Apache Licence Header?
- [x] Are there Doxygen comments in the headers?
- [ ] Are any new features, behaviour changes documented in the .md format [documentation](https://github.com/AnimalLogic/AL_USDMaya/docs)?
- [x] Have you added, updated tests to cover new features and behaviour changes?
- [x] Have you filled out at least one changelog entry?
