### PR TITLE
Sanctify the proxyShape's session layer

### DIFF
--- a/docs/layers.md
+++ b/docs/layers.md
@@ -10,7 +10,7 @@ The LayerManager is a singleton that tracks all layers that have been set as an 
 The tracked layers will be serialised to the Maya scene when the scene is saved, and reapplied when the scene is re-opened.
 To record edits to a layer, you need to set it as the current [Edit Target](https://graphics.pixar.com/usd/docs/USD-Glossary.html#USDGlossary-EditTarget). 
 AL_USDMaya will record which layers have been set as the edit target during a session, and when the scene is saved (via an OnSceneSaved callback) will serialise their content into the maya scene. Those layers will be deserialised into the live USD model after the scene has been opened again via an equivalent OnSceneOpened callback).
-Normally, the default Edit Target in USD will be the Root Layer of the scene, although using the [Session Layer](https://graphics.pixar.com/usd/docs/USD-Glossary.html#USDGlossary-SessionLayer) is something we should consider.
+Normally, the default Edit Target in USD will be the Root Layer of the scene, but the proxyShape sets the [Session Layer](https://graphics.pixar.com/usd/docs/USD-Glossary.html#USDGlossary-SessionLayer) as the default Edit Target. This has several advantages such as: authoring edits as the highest strength opinion, concentrating edits in one place, and avoiding serializing heavy root layers.
 
 ##### Uses at AL
 ###### Modifications for exisiting layers

--- a/lib/AL_USDMaya/AL/usdmaya/fileio/NodeFactory.cpp
+++ b/lib/AL_USDMaya/AL/usdmaya/fileio/NodeFactory.cpp
@@ -101,6 +101,7 @@ MObject NodeFactory::createNode(const UsdPrim& from, const char* const nodeType,
       {
         nodeName += "Shape";
       }
+      // FIXME: calling mapUsdPrimToMayaNode no longer has any effect since it doesn't write to the session layer. Remove this?
       // Write in the shapes parent transform node's path instead of the shape.
       // This was done because we want the xform to be selected when chosen through the outliner instead of the shape.
       AL::usdmaya::utils::mapUsdPrimToMayaNode(from, parent);

--- a/lib/AL_USDMaya/AL/usdmaya/nodes/ProxyShape.cpp
+++ b/lib/AL_USDMaya/AL/usdmaya/nodes/ProxyShape.cpp
@@ -1476,12 +1476,10 @@ bool ProxyShape::lockTransformAttribute(const SdfPath& path, const bool lock)
     return false;
   }
 
-
-  VtValue mayaPath = prim.GetCustomDataByKey(TfToken("MayaPath"));
   MObject lockObject;
-  if (!mayaPath.IsEmpty())
+  MString pathStr = getMayaPathFromUsdPrim(prim);
+  if (pathStr.length())
   {
-    MString pathStr = AL::maya::utils::convert(mayaPath.Get<std::string>());
     MSelectionList sl;
     MObject selObj;
     if (sl.add(pathStr) == MStatus::kSuccess)
@@ -1677,6 +1675,33 @@ bool ProxyShape::primHasExcludedParent(UsdPrim prim)
   return false;
 }
 
+//----------------------------------------------------------------------------------------------------------------------
+MString ProxyShape::recordUsdPrimToMayaPath(const UsdPrim &usdPrim,
+                                            const MObject &mayaObject){
+  // Retrieve the proxy shapes transform path which will be used in the
+  // UsdPrim->MayaNode mapping in the case where there is delayed node creation.
+  MFnDagNode shapeFn(thisMObject());
+  const MObject shapeParent = shapeFn.parent(0);
+  MDagPath mayaPath;
+  MDagPath::getAPathTo(shapeParent, mayaPath);
+
+  MString resultingPath;
+  SdfPath primPath(usdPrim.GetPath());
+  resultingPath = AL::usdmaya::utils::mapUsdPrimToMayaNode(usdPrim, mayaObject, &mayaPath);
+  m_primPathToDagPath.insert(std::make_pair(primPath, resultingPath));
+
+  return resultingPath;
+}
+
+//----------------------------------------------------------------------------------------------------------------------
+MString ProxyShape::getMayaPathFromUsdPrim(const UsdPrim& usdPrim){
+  _PrimPathToDagPath::iterator itr = m_primPathToDagPath.find(usdPrim.GetPath());
+  if (itr == m_primPathToDagPath.end()){
+    TF_DEBUG(ALUSDMAYA_EVALUATION).Msg("ProxyShape::getMayaPathFromUsdPrim could not find stored MayaPath\n");
+    return MString();
+  }
+  return itr->second;
+}
 //----------------------------------------------------------------------------------------------------------------------
 
 void ProxyShape::findTaggedPrims()

--- a/lib/AL_USDMaya/AL/usdmaya/nodes/ProxyShape.cpp
+++ b/lib/AL_USDMaya/AL/usdmaya/nodes/ProxyShape.cpp
@@ -1683,19 +1683,21 @@ MString ProxyShape::recordUsdPrimToMayaPath(const UsdPrim &usdPrim,
   MFnDagNode shapeFn(thisMObject());
   const MObject shapeParent = shapeFn.parent(0);
   MDagPath mayaPath;
+  // Note: This doesn't account for the possibility of multiple paths to a node, but so far this
+  // is only used for recently created transforms that should only have single paths.
   MDagPath::getAPathTo(shapeParent, mayaPath);
 
   MString resultingPath;
   SdfPath primPath(usdPrim.GetPath());
   resultingPath = AL::usdmaya::utils::mapUsdPrimToMayaNode(usdPrim, mayaObject, &mayaPath);
-  m_primPathToDagPath.insert(std::make_pair(primPath, resultingPath));
+  m_primPathToDagPath.emplace(primPath, resultingPath);
 
   return resultingPath;
 }
 
 //----------------------------------------------------------------------------------------------------------------------
 MString ProxyShape::getMayaPathFromUsdPrim(const UsdPrim& usdPrim){
-  _PrimPathToDagPath::iterator itr = m_primPathToDagPath.find(usdPrim.GetPath());
+  PrimPathToDagPath::iterator itr = m_primPathToDagPath.find(usdPrim.GetPath());
   if (itr == m_primPathToDagPath.end()){
     TF_DEBUG(ALUSDMAYA_EVALUATION).Msg("ProxyShape::getMayaPathFromUsdPrim could not find stored MayaPath\n");
     return MString();

--- a/lib/AL_USDMaya/AL/usdmaya/nodes/ProxyShape.cpp
+++ b/lib/AL_USDMaya/AL/usdmaya/nodes/ProxyShape.cpp
@@ -1363,6 +1363,8 @@ void ProxyShape::loadStage()
         UsdStageCache::Id stageId = StageCache::Get().Insert(m_stage);
         outputInt32Value(dataBlock, m_stageCacheId, stageId.ToLongInt());
 
+        // Set the edit target to the session layer so any user interaction will wind up there
+        m_stage->SetEditTarget(m_stage->GetSessionLayer());
         // Save the initial edit target
         trackEditTargetLayer();
 

--- a/lib/AL_USDMaya/AL/usdmaya/nodes/ProxyShape.h
+++ b/lib/AL_USDMaya/AL/usdmaya/nodes/ProxyShape.h
@@ -231,7 +231,7 @@ struct FindLockedPrimsLogic
 };
 
 typedef const HierarchyIterationLogic*  HierarchyIterationLogics[3];
-typedef TfHashMap<SdfPath, MString, SdfPath::Hash > _PrimPathToDagPath;
+typedef std::unordered_map<SdfPath, MString, SdfPath::Hash > PrimPathToDagPath;
 
 extern AL::event::EventId kPreClearStageCache;
 extern AL::event::EventId kPostClearStageCache;
@@ -608,11 +608,16 @@ public:
   void deserialiseTranslatorContext();
 
   /// \brief  gets the maya node path for a prim, stores the mapping and returns it
+  /// \param  usdPrim the prim we are bringing in to maya
+  /// \param  mayaObject the corresponding maya node
+  /// \return  a dag path to the maya object
   AL_USDMAYA_PUBLIC
   MString recordUsdPrimToMayaPath(const UsdPrim &usdPrim,
                                   const MObject &mayaObject);
 
   /// \brief  returns the stored maya node path for a prim
+  /// \param  usdPrim a prim that has been brought into maya
+  /// \return  a dag path to the maya object
   AL_USDMAYA_PUBLIC
   MString getMayaPathFromUsdPrim(const UsdPrim& usdPrim);
 
@@ -1015,7 +1020,7 @@ private:
   FindUnselectablePrimsLogic m_findUnselectablePrims;
   SdfPathHashSet m_selectedPaths;
   FindLockedPrimsLogic m_findLockedPrims;
-  _PrimPathToDagPath m_primPathToDagPath;
+  PrimPathToDagPath m_primPathToDagPath;
   std::vector<SdfPath> m_paths;
   std::vector<UsdPrim> m_prims;
   TfNotice::Key m_objectsChangedNoticeKey;

--- a/lib/AL_USDMaya/AL/usdmaya/nodes/ProxyShape.h
+++ b/lib/AL_USDMaya/AL/usdmaya/nodes/ProxyShape.h
@@ -231,6 +231,7 @@ struct FindLockedPrimsLogic
 };
 
 typedef const HierarchyIterationLogic*  HierarchyIterationLogics[3];
+typedef TfHashMap<SdfPath, MString, SdfPath::Hash > _PrimPathToDagPath;
 
 extern AL::event::EventId kPreClearStageCache;
 extern AL::event::EventId kPostClearStageCache;
@@ -605,6 +606,15 @@ public:
   /// \brief  deserialises the translator context
   AL_USDMAYA_PUBLIC
   void deserialiseTranslatorContext();
+
+  /// \brief  gets the maya node path for a prim, stores the mapping and returns it
+  AL_USDMAYA_PUBLIC
+  MString recordUsdPrimToMayaPath(const UsdPrim &usdPrim,
+                                  const MObject &mayaObject);
+
+  /// \brief  returns the stored maya node path for a prim
+  AL_USDMAYA_PUBLIC
+  MString getMayaPathFromUsdPrim(const UsdPrim& usdPrim);
 
   /// \brief aggregates logic that needs to iterate through the hierarchy looking for properties/metdata on prims
   AL_USDMAYA_PUBLIC
@@ -1005,6 +1015,7 @@ private:
   FindUnselectablePrimsLogic m_findUnselectablePrims;
   SdfPathHashSet m_selectedPaths;
   FindLockedPrimsLogic m_findLockedPrims;
+  _PrimPathToDagPath m_primPathToDagPath;
   std::vector<SdfPath> m_paths;
   std::vector<UsdPrim> m_prims;
   TfNotice::Key m_objectsChangedNoticeKey;

--- a/lib/AL_USDMaya/AL/usdmaya/nodes/ProxyShapeSelection.cpp
+++ b/lib/AL_USDMaya/AL/usdmaya/nodes/ProxyShapeSelection.cpp
@@ -562,15 +562,10 @@ MObject ProxyShape::makeUsdTransformChain(
   fn.setObject(node);
   fn.setName(AL::maya::utils::convert(usdPrim.GetName().GetString()));
 
-  //Retrieve the proxy shapes transform path which will be used in the UsdPrim->MayaNode mapping in the case where there is delayed node creation.
-  MFnDagNode shapeFn(thisMObject());
-  const MObject shapeParent = shapeFn.parent(0);
-  MDagPath mayaPath;
-  MDagPath::getAPathTo(shapeParent, mayaPath);
   if(resultingPath)
-    *resultingPath = AL::usdmaya::utils::mapUsdPrimToMayaNode(usdPrim, node, &mayaPath);
+    *resultingPath = recordUsdPrimToMayaPath(usdPrim, node);
   else
-    AL::usdmaya::utils::mapUsdPrimToMayaNode(usdPrim, node, &mayaPath);
+    recordUsdPrimToMayaPath(usdPrim, node);
 
   if(isUsdTransform)
   {

--- a/plugin/AL_USDMayaTestPlugin/AL/usdmaya/commands/test_LayerManagerCommands.cpp
+++ b/plugin/AL_USDMayaTestPlugin/AL/usdmaya/commands/test_LayerManagerCommands.cpp
@@ -102,6 +102,7 @@ TEST(LayerManagerCommands, dirtySublayer)
     const char* sublayerId = "sublayertest";
     SdfLayerRefPtr sublayer = SdfLayer::CreateAnonymous(sublayerId);
 
+    stage->SetEditTarget(stage->GetRootLayer());
     std::vector<std::string> sublayers;
     sublayers.push_back(sublayer->GetIdentifier());
     stage->GetRootLayer()->SetSubLayerPaths(sublayers);
@@ -172,12 +173,15 @@ TEST(LayerManagerCommands, dirtySublayerSessionLayer)
     sublayers.push_back(sublayer->GetIdentifier());
 
     // this modified the RootLayer
+    stage->SetEditTarget(stage->GetRootLayer());
     stage->GetRootLayer()->SetSubLayerPaths(sublayers);
+    EXPECT_TRUE(stage->GetRootLayer()->IsDirty());
     EXPECT_FALSE(sublayer->IsDirty());
 
     // Now set the EditTarget to the session layer and dirty it
     stage->SetEditTarget(stage->GetSessionLayer());
     stage->DefinePrim(SdfPath("/DirtySublayer"));
+    EXPECT_TRUE(stage->GetSessionLayer()->IsDirty());
 
     stage->SetEditTarget(sublayer);
     result = MGlobal::executeCommand("AL_usdmaya_LayerManager -dal", dirtyLayerPairs, true);

--- a/plugin/AL_USDMayaTestPlugin/AL/usdmaya/nodes/test_LayerManager.cpp
+++ b/plugin/AL_USDMayaTestPlugin/AL/usdmaya/nodes/test_LayerManager.cpp
@@ -463,13 +463,13 @@ TEST(LayerManager, simpleSaveRestore)
 
     auto stage = proxy->getUsdStage();
     auto hip = stage->GetPrimAtPath(hipPath);
-    auto root = stage->GetRootLayer();
+    auto session = stage->GetSessionLayer();
 
     ASSERT_TRUE(hip.HasAttribute(fooToken));
     float outValue;
     hip.GetAttribute(fooToken).Get(&outValue);
     EXPECT_EQ(outValue, fooValue);
-    auto fooLayerAttr = root->GetAttributeAtPath(fooPath);
+    auto fooLayerAttr = session->GetAttributeAtPath(fooPath);
     ASSERT_TRUE(fooLayerAttr);
     EXPECT_EQ(fooLayerAttr->GetDefaultValue(), fooValue);
   };
@@ -501,14 +501,14 @@ TEST(LayerManager, simpleSaveRestore)
 
     auto stage = proxy->getUsdStage();
     auto hip = stage->GetPrimAtPath(hipPath);
-    auto root = stage->GetRootLayer();
+    auto session = stage->GetSessionLayer();
 
     // Verify that initially, in the stage, /root/hip1.foo attribute is not present
     EXPECT_FALSE(hip.HasAttribute(fooToken));
-    EXPECT_FALSE(root->GetAttributeAtPath(fooPath));
+    EXPECT_FALSE(session->GetAttributeAtPath(fooPath));
 
     // Now add the foo attribute
-    EXPECT_EQ(stage->GetEditTarget().GetLayer(), root);
+    EXPECT_EQ(stage->GetEditTarget().GetLayer(), session);
     auto fooStageAttr = hip.CreateAttribute(fooToken, SdfValueTypeNames->Float);
     // ...and set it...
     fooStageAttr.Set(fooValue);
@@ -518,7 +518,7 @@ TEST(LayerManager, simpleSaveRestore)
     float outValue;
     hip.GetAttribute(fooToken).Get(&outValue);
     EXPECT_EQ(outValue, fooValue);
-    auto fooLayerAttr = root->GetAttributeAtPath(fooPath);
+    auto fooLayerAttr = session->GetAttributeAtPath(fooPath);
     ASSERT_TRUE(fooLayerAttr);
     EXPECT_EQ(fooLayerAttr->GetDefaultValue(), fooValue);
   }

--- a/usdmayautils/AL/usdmaya/utils/Utils.cpp
+++ b/usdmayautils/AL/usdmaya/utils/Utils.cpp
@@ -98,12 +98,6 @@ MString mapUsdPrimToMayaNode(const UsdPrim& usdPrim,
 
   UsdStageWeakPtr stage = usdPrim.GetStage();
 
-  // copy the previousTarget, and restore it later
-  UsdEditTarget previousTarget = stage->GetEditTarget();
-  //auto previousLayer = previousTarget.GetLayer();
-  auto sessionLayer = stage->GetSessionLayer();
-  stage->SetEditTarget(sessionLayer);
-
   MFnDagNode mayaNode(mayaObject);
   MDagPath mayaDagPath;
   mayaNode.getPath(mayaDagPath);
@@ -116,13 +110,7 @@ MString mapUsdPrimToMayaNode(const UsdPrim& usdPrim,
     std::replace(mayaElementPath.begin(), mayaElementPath.end(), '/','|');
   }
 
-  VtValue mayaPathValue(mayaElementPath);
-  usdPrim.SetCustomDataByKey(mayaPathAttributeName, mayaPathValue);
-
-  TF_DEBUG(ALUTILS_INFO).Msg("Capturing the path for prim=%s mayaObject=%s\n", usdPrim.GetName().GetText(), mayaElementPath.c_str());
-
-  //restore the edit target
-  stage->SetEditTarget(previousTarget);
+  TF_DEBUG(ALUTILS_INFO).Msg("Mapped the path for prim=%s to mayaObject=%s\n", usdPrim.GetName().GetText(), mayaElementPath.c_str());
 
   return AL::maya::utils::convert(mayaElementPath);
 }

--- a/usdmayautils/AL/usdmaya/utils/Utils.h
+++ b/usdmayautils/AL/usdmaya/utils/Utils.h
@@ -37,13 +37,13 @@ namespace usdmaya {
 namespace utils {
 
 //----------------------------------------------------------------------------------------------------------------------
-/// \brief  Captures the mapping of UsdPrim -> Maya Object and stores it into the session layer.
-///         usdMayaShapeNode is an optional argument, if it is passed and the passed in mayaObject's path couldnt be determined,
+/// \brief  Returns the dagPath result of mapping UsdPrim -> Maya Object.
+///         proxyShapeNode is an optional argument, if it is passed and the passed in mayaObject's path couldn't be determined,
 ///         then the corresponding maya path is determined using this AL::usdmaya::nodes::ProxyShape and the usdPrim path.
 ///         It is to get around the delayed creation of nodes using a Modifier.
 /// \param  usdPrim the prim to map to the mayaObject
 /// \param  mayaObject the maya node to map
-/// \param  proxyShapeNode pointer to the daga path for the proxy shape
+/// \param  proxyShapeNode pointer to the dag path for the proxy shape
 /// \return returns the path name
 /// \ingroup usdmaya
 //----------------------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
Sets the default edit target to the session layer and sanctifies the layer as a place for "session edits" made by maya user's interactions with the stage. 

We believe this default makes a lot of sense and is in line with Usd's philosophy. Some benefits are that:
- Edits won't get mixed into the root layer. A clean session layer can show you exactly what has changed in the scene from the default version of the asset.
- Avoids serializing the root layer in the scene (doing so can be much more data then needed and also sabotages your ability to maintain a live reference to the root layer)
- Highest priority opinion. Avoids any artist confusion if they are making edits that are disregarded because the session layer has an override.
- Useful to concentrate edits in one place so they can be picked up by #99 

In line with the goal of having a clean and succinct location for edits, I have moved the storage of the MayaPath out of the session layer and into the ProxyShape class. It ultimately didn't seem like something that belonged in a layer because the values are only needed in the short term and then not used again. If any external tools need access to the dagPath values we can add a wrapper method to retrieve the path directly.

## Changelog

### Changed
- The initial edit target of proxyShapes has changed from the root layer to the session layer
- The mapping from prim to maya dag path is no longer stored on the session layer, but is stored on the proxyShape class

## Checklist (Please do not remove this line)
- [x] Make sure the Title and Description of the PR make sense and  provide sufficient context for your work
- [x] Do any added files have the correct AL Apache Licence Header?
- [x] Are there Doxygen comments in the headers?
- [x] Are any new features, behaviour changes documented in the .md format [documentation](https://github.com/AnimalLogic/AL_USDMaya/docs)?
- [x] Have you added, updated tests to cover new features and behaviour changes?
- [x] Have you filled out at least one changelog entry?
