### PR TITLE
add missing triggers for Pre/PostStageLoaded events

### DIFF
--- a/lib/AL_USDMaya/AL/usdmaya/nodes/ProxyShape.cpp
+++ b/lib/AL_USDMaya/AL/usdmaya/nodes/ProxyShape.cpp
@@ -1225,6 +1225,8 @@ void ProxyShape::loadStage()
 {
   TF_DEBUG(ALUSDMAYA_EVALUATION).Msg("ProxyShape::loadStage\n");
 
+  triggerEvent("PreStageLoaded");
+
   AL_BEGIN_PROFILE_SECTION(LoadStage);
   MDataBlock dataBlock = forceCache();
   // in case there was already a stage in m_stage, check to see if it's edit target has been altered
@@ -1424,6 +1426,8 @@ void ProxyShape::loadStage()
   }
 
   stageDataDirtyPlug().setValue(true);
+
+  triggerEvent("PostStageLoaded");
 }
 
 //----------------------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
## Description (this won't be part of the changelog)

There were events defined for PreStageLoaded and PostStageLoaded, but they were never triggered. This fixes that.

## Changelog
### Fixed
- added missing triggers for Pre/PostStageLoaded events

## Checklist (Please do not remove this line)
- [X] Make sure the Title and Description of the PR make sense and  provide sufficient context for your work
- [X] Do any added files have the correct AL Apache Licence Header?
- [X] Are there Doxygen comments in the headers?
- [X] Are any new features, behaviour changes documented in the .md format [documentation](https://github.com/AnimalLogic/AL_USDMaya/docs)?
- [ ] Have you added, updated tests to cover new features and behaviour changes?
- [X] Have you filled out at least one changelog entry?
