### PR TITLE
avoid creating do-nothing xform ops

### DIFF
--- a/lib/AL_USDMaya/AL/usdmaya/nodes/TransformationMatrix.cpp
+++ b/lib/AL_USDMaya/AL/usdmaya/nodes/TransformationMatrix.cpp
@@ -1211,7 +1211,7 @@ MStatus TransformationMatrix::translateTo(const MVector& vector, MSpace::Space s
       // helping the branch predictor
     }
     else
-    if(!pushPrimToMatrix())
+    if(!pushPrimToMatrix() && vector != MVector::zero)
     {
       insertTranslateOp();
     }
@@ -1290,7 +1290,7 @@ MStatus TransformationMatrix::scaleTo(const MVector& scale, MSpace::Space space)
       // helping the branch predictor
     }
     else
-    if(!pushPrimToMatrix())
+    if(!pushPrimToMatrix() && scale != MVector::one)
     {
       // rare case: add a new scale op into the prim
       insertScaleOp();
@@ -1362,7 +1362,7 @@ MStatus TransformationMatrix::shearTo(const MVector& shear, MSpace::Space space)
       // helping the branch predictor
     }
     else
-    if(!pushPrimToMatrix())
+    if(!pushPrimToMatrix() && shear != MVector::zero)
     {
       // rare case: add a new scale op into the prim
       insertShearOp();
@@ -1438,7 +1438,7 @@ MStatus TransformationMatrix::setScalePivot(const MPoint& sp, MSpace::Space spac
     {
     }
     else
-    if(!pushPrimToMatrix())
+    if(!pushPrimToMatrix() && sp != MPoint::origin)
     {
       insertScalePivotOp();
     }
@@ -1478,7 +1478,7 @@ MStatus TransformationMatrix::setScalePivotTranslation(const MVector& sp, MSpace
     {
     }
     else
-    if(!pushPrimToMatrix())
+    if(!pushPrimToMatrix() && sp != MVector::zero)
     {
       insertScalePivotTranslationOp();
     }
@@ -1528,7 +1528,7 @@ MStatus TransformationMatrix::setRotatePivot(const MPoint& pivot, MSpace::Space 
     {
     }
     else
-    if(!pushPrimToMatrix())
+    if(!pushPrimToMatrix() && pivot != MPoint::origin)
     {
       insertRotatePivotOp();
     }
@@ -1568,7 +1568,7 @@ MStatus TransformationMatrix::setRotatePivotTranslation(const MVector &vector, M
     {
     }
     else
-    if(!pushPrimToMatrix())
+    if(!pushPrimToMatrix() && vector != MPoint::origin)
     {
       insertRotatePivotTranslationOp();
     }
@@ -1645,7 +1645,7 @@ MStatus TransformationMatrix::rotateTo(const MQuaternion &q, MSpace::Space space
     {
     }
     else
-    if(!pushPrimToMatrix())
+    if(!pushPrimToMatrix() && q != MQuaternion::identity)
     {
       insertRotateOp();
     }
@@ -1701,7 +1701,7 @@ MStatus TransformationMatrix::rotateTo(const MEulerRotation &e, MSpace::Space sp
     {
     }
     else
-    if(!pushPrimToMatrix())
+    if(!pushPrimToMatrix() && e != MEulerRotation::identity)
     {
       insertRotateOp();
     }
@@ -1778,7 +1778,7 @@ MStatus TransformationMatrix::setRotateOrientation(const MQuaternion &q, MSpace:
     {
     }
     else
-    if(!pushPrimToMatrix())
+    if(!pushPrimToMatrix() && q != MQuaternion::identity)
     {
       insertRotateAxesOp();
     }
@@ -1802,7 +1802,7 @@ MStatus TransformationMatrix::setRotateOrientation(const MEulerRotation& euler, 
     {
     }
     else
-    if(!pushPrimToMatrix())
+    if(!pushPrimToMatrix() && euler != MEulerRotation::identity)
     {
       insertRotateAxesOp();
     }

--- a/lib/AL_USDMaya/AL/usdmaya/nodes/TransformationMatrix.cpp
+++ b/lib/AL_USDMaya/AL/usdmaya/nodes/TransformationMatrix.cpp
@@ -1211,7 +1211,7 @@ MStatus TransformationMatrix::translateTo(const MVector& vector, MSpace::Space s
       // helping the branch predictor
     }
     else
-    if(!pushPrimToMatrix() && vector != MVector::zero)
+    if(!pushPrimToMatrix() && vector != MVector(0.0, 0.0, 0.0))
     {
       insertTranslateOp();
     }
@@ -1290,7 +1290,7 @@ MStatus TransformationMatrix::scaleTo(const MVector& scale, MSpace::Space space)
       // helping the branch predictor
     }
     else
-    if(!pushPrimToMatrix() && scale != MVector::one)
+    if(!pushPrimToMatrix() && scale != MVector(1.0, 1.0, 1.0))
     {
       // rare case: add a new scale op into the prim
       insertScaleOp();
@@ -1362,7 +1362,7 @@ MStatus TransformationMatrix::shearTo(const MVector& shear, MSpace::Space space)
       // helping the branch predictor
     }
     else
-    if(!pushPrimToMatrix() && shear != MVector::zero)
+    if(!pushPrimToMatrix() && shear != MVector(0.0, 0.0, 0.0))
     {
       // rare case: add a new scale op into the prim
       insertShearOp();
@@ -1438,7 +1438,7 @@ MStatus TransformationMatrix::setScalePivot(const MPoint& sp, MSpace::Space spac
     {
     }
     else
-    if(!pushPrimToMatrix() && sp != MPoint::origin)
+    if(!pushPrimToMatrix() && sp != MPoint(0.0, 0.0, 0.0, 1.0))
     {
       insertScalePivotOp();
     }
@@ -1478,7 +1478,7 @@ MStatus TransformationMatrix::setScalePivotTranslation(const MVector& sp, MSpace
     {
     }
     else
-    if(!pushPrimToMatrix() && sp != MVector::zero)
+    if(!pushPrimToMatrix() && sp != MVector(0.0, 0.0, 0.0))
     {
       insertScalePivotTranslationOp();
     }
@@ -1528,7 +1528,7 @@ MStatus TransformationMatrix::setRotatePivot(const MPoint& pivot, MSpace::Space 
     {
     }
     else
-    if(!pushPrimToMatrix() && pivot != MPoint::origin)
+    if(!pushPrimToMatrix() && pivot != MPoint(0.0, 0.0, 0.0, 1.0))
     {
       insertRotatePivotOp();
     }
@@ -1568,7 +1568,7 @@ MStatus TransformationMatrix::setRotatePivotTranslation(const MVector &vector, M
     {
     }
     else
-    if(!pushPrimToMatrix() && vector != MPoint::origin)
+    if(!pushPrimToMatrix() && vector != MPoint(0.0, 0.0, 0.0, 1.0))
     {
       insertRotatePivotTranslationOp();
     }
@@ -1645,7 +1645,7 @@ MStatus TransformationMatrix::rotateTo(const MQuaternion &q, MSpace::Space space
     {
     }
     else
-    if(!pushPrimToMatrix() && q != MQuaternion::identity)
+    if(!pushPrimToMatrix() && q != MQuaternion(0.0, 0.0, 0.0, 1.0))
     {
       insertRotateOp();
     }
@@ -1701,7 +1701,7 @@ MStatus TransformationMatrix::rotateTo(const MEulerRotation &e, MSpace::Space sp
     {
     }
     else
-    if(!pushPrimToMatrix() && e != MEulerRotation::identity)
+    if(!pushPrimToMatrix() && e != MEulerRotation(0.0, 0.0, 0.0, MEulerRotation::kXYZ))
     {
       insertRotateOp();
     }
@@ -1778,7 +1778,7 @@ MStatus TransformationMatrix::setRotateOrientation(const MQuaternion &q, MSpace:
     {
     }
     else
-    if(!pushPrimToMatrix() && q != MQuaternion::identity)
+    if(!pushPrimToMatrix() && q != MQuaternion(0.0, 0.0, 0.0, 1.0))
     {
       insertRotateAxesOp();
     }
@@ -1802,7 +1802,7 @@ MStatus TransformationMatrix::setRotateOrientation(const MEulerRotation& euler, 
     {
     }
     else
-    if(!pushPrimToMatrix() && euler != MEulerRotation::identity)
+    if(!pushPrimToMatrix() && euler != MEulerRotation(0.0, 0.0, 0.0, MEulerRotation::kXYZ))
     {
       insertRotateAxesOp();
     }

--- a/plugin/AL_USDMayaTestPlugin/AL/usdmaya/nodes/test_TransformMatrix.cpp
+++ b/plugin/AL_USDMayaTestPlugin/AL/usdmaya/nodes/test_TransformMatrix.cpp
@@ -1142,6 +1142,135 @@ TEST(Transform, matrixAnimationChannels)
   AL_USDMAYA_UNTESTED;
 }
 
+
+// Check that simply querying the value of various xform attrs doesn't create do-nothing ops
+TEST(Transform, emptyOpsNotMade)
+{
+  MStatus status;
+  const char* xformName = "myXform";
+  SdfPath xformPath(std::string("/") + xformName);
+
+  auto constructTransformChain = [&] ()
+  {
+    UsdStageRefPtr stage = UsdStage::CreateInMemory();
+    UsdGeomXform a = UsdGeomXform::Define(stage, xformPath);
+    return stage;
+  };
+
+  MFileIO::newFile(true);
+
+  const std::string temp_path = "/tmp/AL_USDMayaTests_transform_emptyOpsNotMade.usda";
+  std::string sessionLayerContents;
+
+  // generate some data for the proxy shape
+  {
+    auto stage = constructTransformChain();
+    stage->Export(temp_path, false);
+  }
+
+  {
+    MFnDagNode fn;
+    MObject xform = fn.create("transform");
+    MString proxyParentMayaPath = fn.fullPathName();
+    MObject shape = fn.create("AL_usdmaya_ProxyShape", xform);
+    MString proxyShapeMayaPath = fn.fullPathName();
+
+    AL::usdmaya::nodes::ProxyShape* proxy = (AL::usdmaya::nodes::ProxyShape*)fn.userNode();
+
+    // force the stage to load
+    proxy->filePathPlug().setString(temp_path.c_str());
+
+    auto stage = proxy->getUsdStage();
+
+    auto xformPrim = stage->GetPrimAtPath(xformPath);
+    UsdGeomXform xformGeom(xformPrim);
+
+    // Make sure the xform op is initially what's expected
+    auto assertEmptyOps = [&] () {
+      bool resetsXform;
+      auto xformOps = xformGeom.GetOrderedXformOps(&resetsXform);
+      EXPECT_FALSE(resetsXform);
+      EXPECT_EQ(xformOps.size(), 0);
+    };
+
+    {
+      SCOPED_TRACE("initial stage load");
+      assertEmptyOps();
+    }
+
+    // Select the xform, to make it in maya
+    // use "-r" to insulate from previous tests, as default is append
+    MString cmd = MString("AL_usdmaya_ProxyShapeSelect -r -primPath \"")
+        + xformPath.GetText() + "\" -proxy \"" + proxyShapeMayaPath + "\"";
+    MGlobal::executeCommand(cmd);
+
+    MSelectionList sel;
+    EXPECT_TRUE(MGlobal::getActiveSelectionList(sel));
+    EXPECT_EQ(1, sel.length());
+    MObject xformMobj;
+    EXPECT_TRUE(sel.getDependNode(0, xformMobj));
+    MFnTransform xformMfn(xformMobj);
+
+    // Make sure the usd ops haven't changed yet
+    {
+      SCOPED_TRACE("After selection");
+      assertEmptyOps();
+    }
+
+    auto assertEmptyAfterQuerying = [&]() {
+      // Make sure that things are still empty as we query various plugs
+      for (auto& plugName : {
+            "translate",
+            "rotate",
+            "scale",
+            "shear",
+            "rotatePivot",
+            "rotatePivotTranslate",
+            "scalePivot",
+            "scalePivotTranslate",
+            "rotateAxis",
+            "transMinusRotatePivot"
+          })
+      {
+        MPlug basePlug = xformMfn.findPlug(plugName, true, &status);
+        EXPECT_EQ(MS::kSuccess, status);
+
+        for(unsigned int i = 0; i < 3; ++i)
+        {
+          MPlug childPlug = basePlug.child(i, &status);
+          EXPECT_EQ(MS::kSuccess, status);
+
+          SCOPED_TRACE(MString("Pulling on plug: ") + childPlug.name());
+          childPlug.asDouble();
+          assertEmptyOps();
+        }
+      }
+
+      {
+        MPlug plug = xformMfn.findPlug("rotateOrder", true, &status);
+        EXPECT_EQ(MS::kSuccess, status);
+
+        SCOPED_TRACE(MString("Pulling on plug: ") + plug.name());
+        plug.asShort();
+        assertEmptyOps();
+      }
+    };
+
+    {
+      SCOPED_TRACE("Clean querying");
+      assertEmptyAfterQuerying();
+    }
+
+    {
+      SCOPED_TRACE("Querying after dirtying node");
+      MString cmd = MString("dgdirty \"") + xformMfn.partialPathName() + "\";";
+      status = MGlobal::executeCommand(cmd);
+      EXPECT_EQ(MS::kSuccess, status);
+      assertEmptyAfterQuerying();
+    }
+  }
+}
+
 //  TransformationMatrix();
 //  TransformationMatrix(const UsdPrim& prim);
 //  void setPrim(const UsdPrim& prim);


### PR DESCRIPTION
## Description (this won't be part of the changelog)
Currently, any compute evaluation on an xform attr will trigger the creation of a corresponding XformOp - even if nothing has actually changed.

This ensures that, if there is currently no op, and the "new" xform is an identity, we don't create an op that does nothing.

Also adds a test for this

## Changelog
### Fixed
- Don't create do-nothing xform ops

## Checklist (Please do not remove this line)
- [X] Make sure the Title and Description of the PR make sense and  provide sufficient context for your work
- [X] Do any added files have the correct AL Apache Licence Header?
- [X] Are there Doxygen comments in the headers?
- [X] Are any new features, behaviour changes documented in the .md format [documentation](https://github.com/AnimalLogic/AL_USDMaya/docs)?
- [X] Have you added, updated tests to cover new features and behaviour changes?
- [X] Have you filled out at least one changelog entry?
