### PR TITLE
fix shearTweak (was typo setting scaleTweak instead)

### DIFF
--- a/lib/AL_USDMaya/AL/usdmaya/nodes/TransformationMatrix.cpp
+++ b/lib/AL_USDMaya/AL/usdmaya/nodes/TransformationMatrix.cpp
@@ -1290,7 +1290,7 @@ MStatus TransformationMatrix::shearTo(const MVector& shear, MSpace::Space space)
   MStatus status = MPxTransformationMatrix::shearTo(shear, space);
   if(status)
   {
-    m_scaleTweak = MPxTransformationMatrix::shearValue - m_shearFromUsd;
+    m_shearTweak = MPxTransformationMatrix::shearValue - m_shearFromUsd;
   }
   if(pushToPrimAvailable())
   {


### PR DESCRIPTION
## Description (this won't be part of the changelog)

Title basically says it all - instead of setting shearTweak, scaleTweak was getting set (copy/paste type, I'm assuming).

## Changelog
### Fixed
- Fixed setting of shearTweak

## Checklist (Please do not remove this line)
- [X] Make sure the Title and Description of the PR make sense and  provide sufficient context for your work
- [X] Do any added files have the correct AL Apache Licence Header?
- [X] Are there Doxygen comments in the headers?
- [X] Are any new features, behaviour changes documented in the .md format [documentation](https://github.com/AnimalLogic/AL_USDMaya/docs)?
- [ ] Have you added, updated tests to cover new features and behaviour changes?
- [X] Have you filled out at least one changelog entry?
