### PR TITLE
fix check for scalePivotTranslate when enableReadAnimatedValues is changed

### DIFF
--- a/lib/AL_USDMaya/AL/usdmaya/nodes/TransformationMatrix.cpp
+++ b/lib/AL_USDMaya/AL/usdmaya/nodes/TransformationMatrix.cpp
@@ -1881,7 +1881,7 @@ void TransformationMatrix::enableReadAnimatedValues(bool enabled)
       if(primHasScalePivot() || scalePivot() != nullPoint)
         setScalePivot(scalePivot(), MSpace::kTransform, false);
 
-      if(primHasScalePivot() || scalePivot() != nullPoint)
+      if(primHasScalePivotTranslate() || scalePivotTranslation() != nullVec)
         setScalePivotTranslation(scalePivotTranslation(), MSpace::kTransform);
 
       if(primHasRotatePivot() || rotatePivot() != nullPoint)
@@ -1950,7 +1950,7 @@ void TransformationMatrix::enablePushToPrim(bool enabled)
       if(primHasScalePivot() || scalePivot() != nullPoint)
         setScalePivot(scalePivot(), MSpace::kTransform, false);
 
-      if(primHasScalePivotTranslate() || scalePivotTranslation() != nullPoint)
+      if(primHasScalePivotTranslate() || scalePivotTranslation() != nullVec)
         setScalePivotTranslation(scalePivotTranslation(), MSpace::kTransform);
 
       if(primHasRotatePivot() || rotatePivot() != nullPoint)

--- a/lib/AL_USDMaya/AL/usdmaya/nodes/TransformationMatrix.cpp
+++ b/lib/AL_USDMaya/AL/usdmaya/nodes/TransformationMatrix.cpp
@@ -1862,33 +1862,38 @@ void TransformationMatrix::enableReadAnimatedValues(bool enabled)
   // of nothing. This will call my code that will magically construct the transform ops in the right order.
   if(enabled)
   {
+    const MVector nullVec(0, 0, 0);
+    const MVector oneVec(1.0, 1.0, 1.0);
+    const MPoint nullPoint(0, 0, 0);
+    const MQuaternion nullQuat(0, 0, 0, 1.0);
+
     if(!pushPrimToMatrix())
     {
-      if(primHasTranslation() || translation() != MVector::zero)
-        translateBy(MVector::zero);
+      if(primHasTranslation() || translation() != nullVec)
+        translateBy(nullVec);
 
-      if(primHasScale() || scale() != MVector::one)
-        scaleBy(MVector::one);
+      if(primHasScale() || scale() != oneVec)
+        scaleBy(oneVec);
 
-      if(primHasShear() || shear() != MVector::zero)
-        shearBy(MVector::zero);
+      if(primHasShear() || shear() != nullVec)
+        shearBy(nullVec);
 
-      if(primHasScalePivot() || scalePivot() != MPoint::origin)
+      if(primHasScalePivot() || scalePivot() != nullPoint)
         setScalePivot(scalePivot(), MSpace::kTransform, false);
 
-      if(primHasScalePivot() || scalePivot() != MPoint::origin)
+      if(primHasScalePivot() || scalePivot() != nullPoint)
         setScalePivotTranslation(scalePivotTranslation(), MSpace::kTransform);
 
-      if(primHasRotatePivot() || rotatePivot() != MPoint::origin)
+      if(primHasRotatePivot() || rotatePivot() != nullPoint)
         setRotatePivot(rotatePivot(), MSpace::kTransform, false);
 
-      if(primHasRotatePivotTranslate() || rotatePivotTranslation() != MVector::zero)
+      if(primHasRotatePivotTranslate() || rotatePivotTranslation() != nullVec)
         setRotatePivotTranslation(rotatePivotTranslation(), MSpace::kTransform);
 
-      if(primHasRotation() || rotation() != MQuaternion::identity)
-        rotateBy(MQuaternion::identity);
+      if(primHasRotation() || rotation() != nullQuat)
+        rotateBy(nullQuat);
 
-      if(primHasRotateAxes() || rotateOrientation() != MQuaternion::identity)
+      if(primHasRotateAxes() || rotateOrientation() != nullQuat)
         setRotateOrientation(rotateOrientation(), MSpace::kTransform, false);
     }
     else
@@ -1926,33 +1931,38 @@ void TransformationMatrix::enablePushToPrim(bool enabled)
   // of nothing. This will call my code that will magically construct the transform ops in the right order.
   if(enabled && getTimeCode() == UsdTimeCode::Default())
   {
+    const MVector nullVec(0, 0, 0);
+    const MVector oneVec(1.0, 1.0, 1.0);
+    const MPoint nullPoint(0, 0, 0);
+    const MQuaternion nullQuat(0, 0, 0, 1.0);
+
     if(!pushPrimToMatrix())
     {
-      if(primHasTranslation() || translation() != MVector::zero)
-        translateBy(MVector::zero);
+      if(primHasTranslation() || translation() != nullVec)
+        translateBy(nullVec);
 
-      if(primHasScale() || scale() != MVector::one)
-        scaleBy(MVector::one);
+      if(primHasScale() || scale() != oneVec)
+        scaleBy(oneVec);
 
-      if(primHasShear() || shear() != MVector::zero)
-        shearBy(MVector::zero);
+      if(primHasShear() || shear() != nullVec)
+        shearBy(nullVec);
 
-      if(primHasScalePivot() || scalePivot() != MPoint::origin)
+      if(primHasScalePivot() || scalePivot() != nullPoint)
         setScalePivot(scalePivot(), MSpace::kTransform, false);
 
-      if(primHasScalePivotTranslate() || scalePivotTranslation() != MPoint::origin)
+      if(primHasScalePivotTranslate() || scalePivotTranslation() != nullPoint)
         setScalePivotTranslation(scalePivotTranslation(), MSpace::kTransform);
 
-      if(primHasRotatePivot() || rotatePivot() != MPoint::origin)
+      if(primHasRotatePivot() || rotatePivot() != nullPoint)
         setRotatePivot(rotatePivot(), MSpace::kTransform, false);
 
-      if(primHasRotatePivotTranslate() || rotatePivotTranslation() != MVector::zero)
+      if(primHasRotatePivotTranslate() || rotatePivotTranslation() != nullVec)
         setRotatePivotTranslation(rotatePivotTranslation(), MSpace::kTransform);
 
-      if(primHasRotation() || rotation() != MQuaternion::identity)
-        rotateBy(MQuaternion::identity);
+      if(primHasRotation() || rotation() != nullQuat)
+        rotateBy(nullQuat);
 
-      if(primHasRotateAxes() || rotateOrientation() != MQuaternion::identity)
+      if(primHasRotateAxes() || rotateOrientation() != nullQuat)
         setRotateOrientation(rotateOrientation(), MSpace::kTransform, false);
     }
     else


### PR DESCRIPTION
## Description (this won't be part of the changelog)
Fix for the setting of scalePivotTranslate in enableReadAnimatedValues - it was checking scalePivot instead of scalePivotTranslate.

Also, scalePivotTranslate / rotatePivotTranslate are vector values, not points.
Also reverted a change to not use, ie, MVector::zero, per Rob's note here:
https://github.com/AnimalLogic/AL_USDMaya/pull/112#pullrequestreview-152336003

## Changelog
### Fixed
- check for whether scalePivotTranslate needs to be set enableReadAnimatedValues was checking if scalePivot was set, not scalePivotTranslate

## Checklist (Please do not remove this line)
- [X] Make sure the Title and Description of the PR make sense and  provide sufficient context for your work
- [X] Do any added files have the correct AL Apache Licence Header?
- [X] Are there Doxygen comments in the headers?
- [X] Are any new features, behaviour changes documented in the .md format [documentation](https://github.com/AnimalLogic/AL_USDMaya/docs)?
- [ ] Have you added, updated tests to cover new features and behaviour changes?
- [X] Have you filled out at least one changelog entry?
