### PR TITLE
support for linear / quadratic light decay in VP2.0

### DIFF
--- a/lib/AL_USDMaya/AL/usdmaya/nodes/ProxyDrawOverride.cpp
+++ b/lib/AL_USDMaya/AL/usdmaya/nodes/ProxyDrawOverride.cpp
@@ -245,6 +245,17 @@ void ProxyDrawOverride::draw(const MHWRender::MDrawContext& context, const MUser
             {
               MFloatArray fa;
               lightParam->getParameter(paramNames[i], fa);
+              if (fa[0] == 0)
+              {
+                light.SetAttenuation(GfVec3f(1.0f, 0.0f, 0.0f));
+              }
+              else if (fa[0] == 1)
+              {
+                light.SetAttenuation(GfVec3f(0.0f, 1.0f, 0.0f));
+              }
+              else if (fa[0] == 2) {
+                light.SetAttenuation(GfVec3f(0.0f, 0.0f, 1.0f));
+              }
             }
             break;
           case MHWRender::MLightParameterInformation::kDropoff:


### PR DESCRIPTION
## Description (this won't be part of the changelog)
The AL proxy shape will now probably respect the light decay properties (ie, linear, quadratic, none) of lights in the viewport

## Changelog

### Added
- AL proxy shape will now probably respect the light decay properties (ie, linear, quadratic, none) of lights  in the viewport

## Checklist (Please do not remove this line)
- [X] Make sure the Title and Description of the PR make sense and  provide sufficient context for your work
- [X] Do any added files have the correct AL Apache Licence Header?
- [X] Are there Doxygen comments in the headers?
- [ ] Are any new features, behaviour changes documented in the .md format [documentation](https://github.com/AnimalLogic/AL_USDMaya/docs)?
- [ ] Have you added, updated tests to cover new features and behaviour changes?
- [X] Have you filled out at least one changelog entry?
