### PR TITLE
support viewport selection in maya2019 VP2 (retry)

### DIFF
--- a/lib/AL_USDMaya/AL/usdmaya/nodes/ProxyDrawOverride.cpp
+++ b/lib/AL_USDMaya/AL/usdmaya/nodes/ProxyDrawOverride.cpp
@@ -25,7 +25,9 @@
 #include "maya/MBoundingBox.h"
 #include "maya/MDrawContext.h"
 #include "maya/MPoint.h"
+#include "maya/MPointArray.h"
 #include "maya/M3dView.h"
+#include "maya/MSelectionContext.h"
 
 namespace AL {
 namespace usdmaya {
@@ -408,6 +410,406 @@ ProxyShape* ProxyDrawOverride::getShape(const MDagPath& objPath)
   }
   return static_cast<ProxyShape*>(dnNode.userNode());
 }
+
+//----------------------------------------------------------------------------------------------------------------------
+class ProxyDrawOverrideSelectionHelper
+{
+public:
+
+  static SdfPath path_ting(const SdfPath& a, const SdfPath& b, const int c)
+  {
+    m_paths.push_back(a);
+    return a;
+  }
+  static SdfPathVector m_paths;
+};
+SdfPathVector ProxyDrawOverrideSelectionHelper::m_paths;
+
+
+#if MAYA_API_VERSION >= 20190000
+//----------------------------------------------------------------------------------------------------------------------
+bool ProxyDrawOverride::userSelect(
+    const MHWRender::MSelectionInfo& selectInfo,
+    const MHWRender::MDrawContext& context,
+    const MDagPath& objPath,
+    const MUserData* data,
+    MSelectionList& selectionList,
+    MPointArray& worldSpaceHitPts)
+{
+  TF_DEBUG(ALUSDMAYA_SELECTION).Msg("ProxyDrawOverride::userSelect\n");
+  MStatus status;
+
+  M3dView view = M3dView::active3dView();
+
+  // Get view matrix
+  MMatrix viewMatrix = context.getMatrix(MHWRender::MFrameContext::kViewMtx, &status);
+  if (status != MStatus::kSuccess) return false;
+
+  // Get projection matrix
+  MMatrix projectionMatrix = context.getMatrix(MHWRender::MFrameContext::kProjectionMtx, &status);
+  if (status != MStatus::kSuccess) return false;
+
+  // Get world to local matrix
+  MMatrix invMatrix = objPath.inclusiveMatrixInverse();
+  GfMatrix4d worldToLocalSpace(invMatrix.matrix);
+
+  UsdImagingGLEngine::RenderParams params;
+
+  GLuint glHitRecord;
+  view.beginSelect(&glHitRecord, 1);
+  glGetDoublev(GL_MODELVIEW_MATRIX, viewMatrix[0]);
+  glGetDoublev(GL_PROJECTION_MATRIX, projectionMatrix[0]);
+  view.endSelect();
+
+  auto* proxyShape = static_cast<ProxyShape*>(getShape(objPath));
+  auto engine = proxyShape->engine();
+  proxyShape->m_pleaseIgnoreSelection = true;
+
+  UsdPrim root = proxyShape->getUsdStage()->GetPseudoRoot();
+
+  UsdImagingGLEngine::HitBatch hitBatch;
+  SdfPathVector rootPath;
+  rootPath.push_back(root.GetPath());
+
+  int resolution = 10;
+  MGlobal::getOptionVarValue("AL_usdmaya_selectResolution", resolution);
+  if (resolution < 10) { resolution = 10; }
+  if (resolution > 1024) { resolution = 1024; }
+
+
+  bool hitSelected = engine->TestIntersectionBatch(
+          GfMatrix4d(viewMatrix.matrix),
+          GfMatrix4d(projectionMatrix.matrix),
+          worldToLocalSpace,
+          rootPath,
+          params,
+          resolution,
+          ProxyDrawOverrideSelectionHelper::path_ting,
+          &hitBatch);
+
+  auto selected = false;
+
+  auto getHitPath = [&engine] (UsdImagingGLEngine::HitBatch::const_reference& it) -> SdfPath
+  {
+    const UsdImagingGLEngine::HitInfo& hit = it.second;
+    auto path = engine->GetPrimPathFromInstanceIndex(it.first, hit.hitInstanceIndex);
+    if (!path.IsEmpty())
+    {
+      return path;
+    }
+
+    return it.first.StripAllVariantSelections();
+  };
+
+
+  auto addSelection = [&hitBatch, &selectInfo, &selectionList,
+    &worldSpaceHitPts, proxyShape, &selected,
+    &getHitPath] (const MString& command)
+  {
+    selected = true;
+    MStringArray nodes;
+    MGlobal::executeCommand(command, nodes, false, true);
+    
+    uint32_t i = 0;
+    for(auto it = hitBatch.begin(), e = hitBatch.end(); it != e; ++it, ++i)
+    {
+      auto path = getHitPath(*it).StripAllVariantSelections();
+      auto obj = proxyShape->findRequiredPath(path);
+      if (obj != MObject::kNullObj) 
+      {
+        MFnDagNode dagNode(obj);
+        MDagPath dg;
+        dagNode.getPath(dg);
+        const double* p = it->second.worldSpaceHitPoint.GetArray();
+        
+        selectionList.add(dg);
+        worldSpaceHitPts.append(MPoint(p[0], p[1], p[2]));
+      }
+    }
+  };
+  
+
+  // Currently we have two approaches to selection. One method works with undo (but does not
+  // play nicely with maya geometry). The second method doesn't work with undo, but does play
+  // nicely with maya geometry.
+  const int selectionMode = MGlobal::optionVarIntValue("AL_usdmaya_selectMode");
+  if(1 == selectionMode)
+  {
+    if(hitSelected)
+    {
+      int mods;
+      MString cmd = "getModifiers";
+      MGlobal::executeCommand(cmd, mods);
+
+      bool shiftHeld = (mods % 2);
+      bool ctrlHeld = (mods / 4 % 2);
+      MGlobal::ListAdjustment mode = MGlobal::kReplaceList;
+      if(shiftHeld && ctrlHeld)
+        mode = MGlobal::kAddToList;
+      else
+      if(ctrlHeld)
+        mode = MGlobal::kRemoveFromList;
+      else
+      if(shiftHeld)
+        mode = MGlobal::kXORWithList;
+      
+      MString command = "AL_usdmaya_ProxyShapeSelect";
+      switch(mode)
+      {
+      case MGlobal::kReplaceList: command += " -r"; break;
+      case MGlobal::kRemoveFromList: command += " -d"; break;
+      case MGlobal::kXORWithList: command += " -tgl"; break;
+      case MGlobal::kAddToList: command += " -a"; break;
+      case MGlobal::kAddToHeadOfList: /* should never get here */ break;
+      }
+
+      for(auto it = hitBatch.begin(), e = hitBatch.end(); it != e; ++it)
+      {
+        auto path = getHitPath(*it);
+        command += " -pp \"";
+        command += path.GetText();
+        command += "\"";
+      }
+
+      MFnDependencyNode fn(proxyShape->thisMObject());
+      command += " \"";
+      command += fn.name();
+      command += "\"";
+      MGlobal::executeCommandOnIdle(command, false);
+    }
+    else
+    {
+      MString command = "AL_usdmaya_ProxyShapeSelect -cl ";
+      MFnDependencyNode fn(proxyShape->thisMObject());
+      command += " \"";
+      command += fn.name();
+      command += "\"";
+      MGlobal::executeCommandOnIdle(command, false);
+    }
+  }
+  else
+  {
+    int mods;
+    MString cmd = "getModifiers";
+    MGlobal::executeCommand(cmd, mods);
+    
+    bool shiftHeld = (mods % 2);
+    bool ctrlHeld = (mods / 4 % 2);
+    MGlobal::ListAdjustment mode = MGlobal::kReplaceList;
+    if(shiftHeld && ctrlHeld)
+      mode = MGlobal::kAddToList;
+    else
+    if(ctrlHeld)
+      mode = MGlobal::kRemoveFromList;
+    else
+    if(shiftHeld)
+      mode = MGlobal::kXORWithList;
+
+    SdfPathVector paths;
+    if (!hitBatch.empty())
+    {
+      paths.reserve(hitBatch.size());
+
+      auto addHit = [&engine, &paths, &getHitPath](UsdImagingGLEngine::HitBatch::const_reference& it)
+      {
+        paths.push_back(getHitPath(it));
+      };
+
+      // Do to the inaccuracies in the selection method in gl engine
+      // we still need to find the closest selection.
+      // Around the edges it often selects two or more prims.
+      if (selectInfo.singleSelection())
+      {
+        auto closestHit = hitBatch.cbegin();
+
+        if (hitBatch.size() > 1)
+        {
+          MDagPath cameraPath;
+          view.getCamera(cameraPath);
+          const auto cameraPoint = cameraPath.inclusiveMatrix() * MPoint(0.0, 0.0, 0.0, 1.0);
+          auto distanceToCameraSq = [&cameraPoint] (UsdImagingGLEngine::HitBatch::const_reference& it) -> double
+          {
+            const auto dx = cameraPoint.x - it.second.worldSpaceHitPoint[0];
+            const auto dy = cameraPoint.y - it.second.worldSpaceHitPoint[1];
+            const auto dz = cameraPoint.z - it.second.worldSpaceHitPoint[2];
+            return dx * dx + dy * dy + dz * dz;
+          };
+
+          auto closestDistance = distanceToCameraSq(*closestHit);
+          for (auto it = ++hitBatch.cbegin(), itEnd = hitBatch.cend(); it != itEnd; ++it)
+          {
+            const auto currentDistance = distanceToCameraSq(*it);
+            if (currentDistance < closestDistance)
+            {
+              closestDistance = currentDistance;
+              closestHit = it;
+            }
+          }
+        }
+        addHit(*closestHit);
+      }
+      else
+      {
+        for (const auto& it : hitBatch)
+        {
+          addHit(it);
+        }
+      }
+    }
+
+    switch(mode)
+    {
+    case MGlobal::kReplaceList:
+      {
+        MString command;
+        if(!proxyShape->selectedPaths().empty())
+        {
+          command = "AL_usdmaya_ProxyShapeSelect -i -cl ";
+          MFnDependencyNode fn(proxyShape->thisMObject());
+          command += " \"";
+          command += fn.name();
+          command += "\";";
+        }
+
+        if(!paths.empty())
+        {
+          command += "AL_usdmaya_ProxyShapeSelect -i -a ";
+          for(const auto& it : paths)
+          {
+            command += " -pp \"";
+            command += it.GetText();
+            command += "\"";
+          }
+          MFnDependencyNode fn(proxyShape->thisMObject());
+          command += " \"";
+          command += fn.name();
+          command += "\"";
+
+        }
+
+        if(command.length() > 0)
+        {
+          addSelection(command);
+        }
+      }
+      break;
+
+    case MGlobal::kAddToHeadOfList:
+    case MGlobal::kAddToList:
+      {
+        MString command;
+        if(paths.size())
+        {
+          command = "AL_usdmaya_ProxyShapeSelect -i -a ";
+          for(auto it : paths)
+          {
+            command += " -pp \"";
+            command += it.GetText();
+            command += "\"";
+          }
+          MFnDependencyNode fn(proxyShape->thisMObject());
+          command += " \"";
+          command += fn.name();
+          command += "\"";
+        }
+
+        if(command.length() > 0)
+        {
+          selected = true;
+          addSelection(command);
+        }
+      }
+      break;
+
+    case MGlobal::kRemoveFromList:
+      {
+        if(!proxyShape->selectedPaths().empty() && paths.size())
+        {
+          MString command = "AL_usdmaya_ProxyShapeSelect -d ";
+          for(auto it : paths)
+          {
+            command += " -pp \"";
+            command += it.GetText();
+            command += "\"";
+          }
+          MFnDependencyNode fn(proxyShape->thisMObject());
+          command += " \"";
+          command += fn.name();
+          command += "\"";
+          MGlobal::executeCommandOnIdle(command, false);
+          
+        }
+      }
+      break;
+
+    case MGlobal::kXORWithList:
+      {
+        auto& slpaths = proxyShape->selectedPaths();
+        bool hasSelectedItems = false;
+        bool hasDeletedItems = false;
+
+        MString selectcommand = "AL_usdmaya_ProxyShapeSelect -i -a ";
+        MString deselectcommand = "AL_usdmaya_ProxyShapeSelect -d ";
+        for(auto it : paths)
+        {
+          bool flag = false;
+          for(auto sit : slpaths)
+          {
+            if(sit == it)
+            {
+              flag = true;
+              break;
+            }
+          }
+          if(flag)
+          {
+            deselectcommand += " -pp \"";
+            deselectcommand += it.GetText();
+            deselectcommand += "\"";
+            hasDeletedItems = true;
+          }
+          else
+          {
+            selectcommand += " -pp \"";
+            selectcommand += it.GetText();
+            selectcommand += "\"";
+            hasSelectedItems = true;
+          }
+        }
+        MFnDependencyNode fn(proxyShape->thisMObject());
+        selectcommand += " \"";
+        selectcommand += fn.name();
+        selectcommand += "\"";
+        deselectcommand += " \"";
+        deselectcommand += fn.name();
+        deselectcommand += "\"";
+
+        if(hasSelectedItems)
+        {
+          addSelection(selectcommand);
+        }
+
+        if(hasDeletedItems)
+        {
+          MGlobal::executeCommandOnIdle(deselectcommand, false);
+        }
+      }
+      break;
+    }
+
+    MString final_command = "AL_usdmaya_ProxyShapePostSelect \"";
+    MFnDependencyNode fn(proxyShape->thisMObject());
+    final_command += fn.name();
+    final_command += "\"";
+    proxyShape->setChangedSelectionState(true);
+    MGlobal::executeCommandOnIdle(final_command, false);
+  }
+
+  ProxyDrawOverrideSelectionHelper::m_paths.clear();
+  
+  return selected;
+}
+#endif
 
 //----------------------------------------------------------------------------------------------------------------------
 } // nodes

--- a/lib/AL_USDMaya/AL/usdmaya/nodes/ProxyDrawOverride.h
+++ b/lib/AL_USDMaya/AL/usdmaya/nodes/ProxyDrawOverride.h
@@ -121,6 +121,19 @@ public:
 
 private:
   static MUint64 s_lastRefreshFrameStamp;
+  
+#if MAYA_API_VERSION >= 20190000
+  bool wantUserSelection() const override {return true;}
+  
+  bool userSelect(
+      const MHWRender::MSelectionInfo& selectInfo,
+      const MHWRender::MDrawContext& context,
+      const MDagPath& objPath,
+      const MUserData* data,
+      MSelectionList& selectionList,
+      MPointArray& worldSpaceHitPts) override;
+#endif
+
 };
 
 //----------------------------------------------------------------------------------------------------------------------

--- a/lib/AL_USDMaya/AL/usdmaya/nodes/ProxyShape.cpp
+++ b/lib/AL_USDMaya/AL/usdmaya/nodes/ProxyShape.cpp
@@ -2159,6 +2159,13 @@ void ProxyShape::registerEvents()
 }
 
 //----------------------------------------------------------------------------------------------------------------------
+MSelectionMask ProxyShape::getShapeSelectionMask() const
+{
+  MSelectionMask::SelectionType selType = MSelectionMask::kSelectMeshes;
+  return MSelectionMask(selType);
+}
+
+//----------------------------------------------------------------------------------------------------------------------
 } // nodes
 } // usdmaya
 } // AL

--- a/lib/AL_USDMaya/AL/usdmaya/nodes/ProxyShape.h
+++ b/lib/AL_USDMaya/AL/usdmaya/nodes/ProxyShape.h
@@ -251,6 +251,7 @@ class ProxyShape
   friend struct SelectionUndoHelper;
   friend class ProxyShapeUI;
   friend class StageReloadGuard;
+  friend class ProxyDrawOverride;
 public:
 
   // returns the shape's parent transform
@@ -838,6 +839,10 @@ public:
   /// \return the separated list of paths
   AL_USDMAYA_PUBLIC
   SdfPathVector getPrimPathsFromCommaJoinedString(const MString &paths) const;
+
+  /// \brief  Returns the selection mask of the shape
+  AL_USDMAYA_PUBLIC
+  MSelectionMask getShapeSelectionMask() const override;
 
 private:
 


### PR DESCRIPTION
## Description
Implements VP2 selection in maya2019 thanks to the new MPxDrawOverride::userSelect() interface 
(Duplicated of pull request #108. Now merging into develop branch. Discard pull request #108)  

## Changelog

### Added

- Implementation of new ProxyDrawOverride::userSelect() provided with maya2019
- Implementation of ProxyShape::getShapeSelectionMask()

## Checklist (Please do not remove this line)
- [x] Make sure the Title and Description of the PR make sense and  provide sufficient context for your work
- [ ] Do any added files have the correct AL Apache Licence Header?
- [x] Are there Doxygen comments in the headers?
- [ ] Are any new features, behaviour changes documented in the .md format [documentation](https://github.com/AnimalLogic/AL_USDMaya/docs)?
- [ ] Have you added, updated tests to cover new features and behaviour changes?
- [x] Have you filled out at least one changelog entry?
