### PR TITLE
respect the maya viewport setting "use default material" for proxyShapes

### DIFF
--- a/lib/AL_USDMaya/AL/usdmaya/nodes/ProxyShape.cpp
+++ b/lib/AL_USDMaya/AL/usdmaya/nodes/ProxyShape.cpp
@@ -537,6 +537,9 @@ bool ProxyShape::getRenderAttris(void* pattribs, const MHWRender::MFrameContext&
     attribs.drawMode = UsdImagingGLEngine::DRAW_POINTS;
   }
 
+  // determine whether to use the default material for everything
+  attribs.enableSceneMaterials = !(displayStyle & MHWRender::MFrameContext::kDefaultMaterial);
+
   // set the time for the scene
   attribs.frame = outTimePlug().asMTime().as(MTime::uiUnit());
 


### PR DESCRIPTION
## Description
This PR hooks up the maya viewport setting "use default material" to a new hydra feature that can render all the objects with a fallback material.

## Changelog
### Added
- support for displaying proxyShapes with default materials instead of full gl shaders for performance by toggling maya's "use default material" option

## Checklist (Please do not remove this line)
- [x] Make sure the Title and Description of the PR make sense and  provide sufficient context for your work
- [x] Do any added files have the correct AL Apache Licence Header?
- [x] Are there Doxygen comments in the headers?
- [x] Are any new features, behaviour changes documented in the .md format [documentation](https://github.com/AnimalLogic/AL_USDMaya/docs)?
- [x] Have you added, updated tests to cover new features and behaviour changes?
- [x] Have you filled out at least one changelog entry?
