### PR TITLE
Enable blending for transparent objects

### DIFF
--- a/lib/AL_USDMaya/AL/usdmaya/nodes/ProxyDrawOverride.cpp
+++ b/lib/AL_USDMaya/AL/usdmaya/nodes/ProxyDrawOverride.cpp
@@ -397,7 +397,16 @@ void ProxyDrawOverride::draw(const MHWRender::MDrawContext& context, const MUser
       ptr->m_engine->RenderBatch(combined, params);
     }
 
-    ptr->m_engine->Render(ptr->m_rootPrim, ptr->m_params);
+    glPushAttrib(GL_COLOR_BUFFER_BIT);
+    glEnable(GL_BLEND);
+    glBlendColor(0.0f, 0.0f, 0.0f, 0.0f);
+    glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
+    glBlendEquation(GL_FUNC_ADD);
+    auto params = ptr->m_params;
+    params.applyRenderState = false;
+    params.alphaThreshold = 0.0f;
+    ptr->m_engine->Render(ptr->m_rootPrim, params);
+    glPopAttrib();
     
     // HACK: Maya doesn't restore this ONE buffer binding after our override is done so we have to do it for them.
     glBindBufferBase(GL_UNIFORM_BUFFER, 4, uboBinding);

--- a/lib/AL_USDMaya/AL/usdmaya/nodes/ProxyDrawOverride.h
+++ b/lib/AL_USDMaya/AL/usdmaya/nodes/ProxyDrawOverride.h
@@ -107,6 +107,8 @@ public:
   AL_USDMAYA_PUBLIC
   static ProxyShape* getShape(const MDagPath& objPath);
 
+  bool isTransparent() const override { return true; }
+
   /// \brief  We support the legacy and VP2 core profile rendering.
   /// \return MHWRender::kOpenGL | MHWRender::kOpenGLCoreProfile
   MHWRender::DrawAPI supportedDrawAPIs() const override


### PR DESCRIPTION
## Description (this won't be part of the changelog)
Enabling blending for the proxy shape, so semi-transparent objects show up properly in the viewport.
## Changelog
> These entries will be used to update the changelog.

> Use Markdown list syntax for each entry.

> Filled out fields will be added to the changelog.

Enabling blending for transparent objects while displaying the Proxy Shape.

### Added

### Changed

### Deprecated

### Removed

### Fixed

## Checklist (Please do not remove this line)
- [ ] Make sure the Title and Description of the PR make sense and  provide sufficient context for your work
- [ ] Do any added files have the correct AL Apache Licence Header?
- [ ] Are there Doxygen comments in the headers?
- [ ] Are any new features, behaviour changes documented in the .md format [documentation](https://github.com/AnimalLogic/AL_USDMaya/docs)?
- [ ] Have you added, updated tests to cover new features and behaviour changes?
- [ ] Have you filled out at least one changelog entry?
