### PR TITLE
Fix FindMaya module not always finding Maya

### DIFF
--- a/cmake/modules/FindMaya.cmake
+++ b/cmake/modules/FindMaya.cmake
@@ -165,7 +165,9 @@ find_path(MAYA_DEVKIT_INC_DIR
         "Maya's devkit headers path"
 )
 
-list(APPEND MAYA_INCLUDE_DIRS ${MAYA_DEVKIT_INC_DIR})
+if(NOT "${MAYA_DEVKIT_INC_DIR}" STREQUAL "MAYA_DEVKIT_INC_DIR-NOTFOUND")
+    list(APPEND MAYA_INCLUDE_DIRS ${MAYA_DEVKIT_INC_DIR})
+endif()
 
 foreach(MAYA_LIB
     OpenMaya


### PR DESCRIPTION
## Description (this won't be part of the changelog)

Fix to resolve #126 where the FindMaya module might fail to find Maya.
The code change is copying the FindMaya module in Pixar's USD repo (https://github.com/PixarAnimationStudios/USD/blob/dev/cmake/modules/FindMaya.cmake) 

## Changelog

### Fixed

- FindMaya cmake module checking MAYA_DEVKIT_INC_DIR before using it

## Checklist (Please do not remove this line)
- [x] Make sure the Title and Description of the PR make sense and  provide sufficient context for your work
- [x] Do any added files have the correct AL Apache Licence Header?
- [x] Are there Doxygen comments in the headers?
- [x] Are any new features, behaviour changes documented in the .md format [documentation](https://github.com/AnimalLogic/AL_USDMaya/docs)?
- [ ] Have you added, updated tests to cover new features and behaviour changes?
- [x] Have you filled out at least one changelog entry?
