### PR TITLE
consolidate MayaReference update logic to make it more resilient

### DIFF
--- a/plugin/AL_USDMayaTestPlugin/AL/usdmaya/nodes/test_ActiveInactive.cpp
+++ b/plugin/AL_USDMayaTestPlugin/AL/usdmaya/nodes/test_ActiveInactive.cpp
@@ -624,7 +624,7 @@ TEST_F(ActiveInactive, disable)
         // should be able to set the variant back to a sphere
         EXPECT_TRUE(actualSet.SetVariantSelection("sphere"));
 
-        // sphere should not be there, but the cube should be
+        // sphere should be there, but the cube should not be
         EXPECT_TRUE(bool(sl.add("dave:pSphere1")));
         EXPECT_TRUE(bool(sl.add("dave:pSphereShape1")));
         EXPECT_TRUE(bool(sl.add("dave:polySphere1")));
@@ -634,7 +634,7 @@ TEST_F(ActiveInactive, disable)
         EXPECT_EQ(3, sl.length());
         sl.clear();
 
-        // should be able to set the variant back to a sphere
+        // should be able to set the variant back to a cube
         EXPECT_TRUE(actualSet.SetVariantSelection("cube"));
 
         // sphere should not be there, but the cube should be
@@ -647,10 +647,10 @@ TEST_F(ActiveInactive, disable)
         EXPECT_EQ(3, sl.length());
         sl.clear();
 
-        // should be able to set the variant back to a sphere
+        // should be able to set the variant to cube with ns fred
         EXPECT_TRUE(actualSet.SetVariantSelection("fredcube"));
 
-        // sphere should not be there, but the cube should be
+        // cube ref should be loaded under ns fred
         EXPECT_FALSE(bool(sl.add("dave:pSphere1")));
         EXPECT_FALSE(bool(sl.add("dave:pSphereShape1")));
         EXPECT_FALSE(bool(sl.add("dave:polySphere1")));
@@ -662,7 +662,7 @@ TEST_F(ActiveInactive, disable)
         EXPECT_TRUE(bool(sl.add("fred:polyCube1")));
         sl.clear();
 
-        // should be able to set the variant back to a sphere
+        // should be able to set the variant back to a cube with ns dave
         EXPECT_TRUE(actualSet.SetVariantSelection("cube"));
 
         // sphere should not be there, but the cube should be
@@ -722,6 +722,30 @@ TEST_F(ActiveInactive, disable)
           MItDependencyNodes iter(MFn::kPluginTransformNode);
           EXPECT_FALSE(iter.isDone());
         }
+
+        // Make sure the same prim can only bring in one copy of a reference.
+        fn.findPlug("pauseUpdates").setBool(True);
+        EXPECT_TRUE(actualSet.SetVariantSelection("sphere"));
+        EXPECT_TRUE(actualSet.SetVariantSelection("fredcube"));
+        fn.findPlug("pauseUpdates").setBool(False);
+        // Make sure we only got one ref
+        EXPECT_TRUE(bool(sl.add("fred:pCube1")));
+        EXPECT_FALSE(bool(sl.add("fred1:pCube1")));
+
+        // import a reference, and make sure a new ref is created on a resync.
+        MString command;
+        command = "file -importReference \"";
+        command += temp_path_cube.asChar();
+        command += "\";";
+        MStatus status = MGlobal::executeCommand(command);
+        EXPECT_EQ(MStatus(MS::kSuccess), status);
+        // old imported reference
+        EXPECT_TRUE(bool(sl.add("fred:pCube1")));
+        proxy->resync(SdfPath("/"));
+        // new reference created on resync
+        EXPECT_TRUE(bool(sl.add("fred1:pCube1")));
+        // old will still exist
+        EXPECT_TRUE(bool(sl.add("fred:pCube1")));
       }
     }
   }

--- a/plugin/AL_USDMayaTestPlugin/AL/usdmaya/nodes/test_ActiveInactive.cpp
+++ b/plugin/AL_USDMayaTestPlugin/AL/usdmaya/nodes/test_ActiveInactive.cpp
@@ -648,6 +648,8 @@ TEST_F(ActiveInactive, disable)
         sl.clear();
 
         // should be able to set the variant to cube with ns fred
+        // Make sure the same prim will only bring in one copy of a reference.
+        // "cube" -> "fredcube: same filepath, but new ns
         EXPECT_TRUE(actualSet.SetVariantSelection("fredcube"));
 
         // cube ref should be loaded under ns fred
@@ -678,10 +680,10 @@ TEST_F(ActiveInactive, disable)
         EXPECT_EQ(3, sl.length());
         sl.clear();
 
-        // should be able to set the variant back to a sphere
+        // should be able to set the variant back to a cached sphere
         EXPECT_TRUE(actualSet.SetVariantSelection("cache"));
 
-        // sphere should not be there, but the cube should be
+        // no refs should be loaded anymore
         EXPECT_FALSE(bool(sl.add("dave:pSphere1")));
         EXPECT_FALSE(bool(sl.add("dave:pSphereShape1")));
         EXPECT_FALSE(bool(sl.add("dave:polySphere1")));
@@ -704,7 +706,7 @@ TEST_F(ActiveInactive, disable)
         // transform chain has re-appeared, and the correct reference has been imported into the scene
         EXPECT_TRUE(actualSet.SetVariantSelection("cube"));
 
-        // sphere should not be there, but the cube should be
+        // only the cube should be loaded
         EXPECT_FALSE(bool(sl.add("dave:pSphere1")));
         EXPECT_FALSE(bool(sl.add("dave:pSphereShape1")));
         EXPECT_FALSE(bool(sl.add("dave:polySphere1")));
@@ -723,15 +725,6 @@ TEST_F(ActiveInactive, disable)
           EXPECT_FALSE(iter.isDone());
         }
 
-        // Make sure the same prim can only bring in one copy of a reference.
-        fn.findPlug("pauseUpdates").setBool(True);
-        EXPECT_TRUE(actualSet.SetVariantSelection("sphere"));
-        EXPECT_TRUE(actualSet.SetVariantSelection("fredcube"));
-        fn.findPlug("pauseUpdates").setBool(False);
-        // Make sure we only got one ref
-        EXPECT_TRUE(bool(sl.add("fred:pCube1")));
-        EXPECT_FALSE(bool(sl.add("fred1:pCube1")));
-
         // import a reference, and make sure a new ref is created on a resync.
         MString command;
         command = "file -importReference \"";
@@ -740,12 +733,12 @@ TEST_F(ActiveInactive, disable)
         MStatus status = MGlobal::executeCommand(command);
         EXPECT_EQ(MStatus(MS::kSuccess), status);
         // old imported reference
-        EXPECT_TRUE(bool(sl.add("fred:pCube1")));
+        EXPECT_TRUE(bool(sl.add("dave:pCube1")));
         proxy->resync(SdfPath("/"));
         // new reference created on resync
-        EXPECT_TRUE(bool(sl.add("fred1:pCube1")));
+        EXPECT_TRUE(bool(sl.add("dave1:pCube1")));
         // old will still exist
-        EXPECT_TRUE(bool(sl.add("fred:pCube1")));
+        EXPECT_TRUE(bool(sl.add("dave:pCube1")));
       }
     }
   }

--- a/plugin/AL_USDMayaTestPlugin/AL/usdmaya/nodes/test_ActiveInactive.cpp
+++ b/plugin/AL_USDMayaTestPlugin/AL/usdmaya/nodes/test_ActiveInactive.cpp
@@ -726,19 +726,21 @@ TEST_F(ActiveInactive, disable)
         }
 
         // import a reference, and make sure a new ref is created on a resync.
+        EXPECT_TRUE(bool(sl.add("dave:pCube1")));
+        EXPECT_FALSE(bool(sl.add("dave1:pCube1")));
         MString command;
         command = "file -importReference \"";
         command += temp_path_cube.asChar();
         command += "\";";
         MStatus status = MGlobal::executeCommand(command);
         EXPECT_EQ(MStatus(MS::kSuccess), status);
-        // old imported reference
+        // old reference is now imported
         EXPECT_TRUE(bool(sl.add("dave:pCube1")));
+        EXPECT_FALSE(bool(sl.add("dave1:pCube1")));
         proxy->resync(SdfPath("/"));
-        // new reference created on resync
-        EXPECT_TRUE(bool(sl.add("dave1:pCube1")));
-        // old will still exist
+        // old will still exist and a new reference has been created
         EXPECT_TRUE(bool(sl.add("dave:pCube1")));
+        EXPECT_TRUE(bool(sl.add("dave1:pCube1")));
       }
     }
   }

--- a/translators/MayaReference.cpp
+++ b/translators/MayaReference.cpp
@@ -127,10 +127,7 @@ MStatus MayaReference::initialize()
 MStatus MayaReference::import(const UsdPrim& prim, MObject& parent, MObject& createdObj)
 {
   TF_DEBUG(ALUSDMAYA_TRANSLATORS).Msg("MayaReference::import prim=%s\n", prim.GetPath().GetText());
-  MStatus status;
-  status = m_mayaReferenceLogic.LoadMayaReference(prim, parent, context());
-
-  return status;
+  return m_mayaReferenceLogic.update(prim, parent);
 }
 
 //----------------------------------------------------------------------------------------------------------------------
@@ -152,171 +149,42 @@ MStatus MayaReference::update(const UsdPrim& prim)
   MObjectHandle handle;
   if(!context()->getTransform(prim, handle))
   {
-    MGlobal::displayError(MString("MayaReference::update unable to find the reference node for prim: ") + prim.GetPath().GetText());
+    MGlobal::displayError(MString("MayaReference::update unable to find the transform node for prim: ") + prim.GetPath().GetText());
   }
-  return m_mayaReferenceLogic.update(prim, handle.object());
+  MObject parent = handle.object();
+  return m_mayaReferenceLogic.update(prim, parent);
 }
 
 //----------------------------------------------------------------------------------------------------------------------
-MStatus MayaReferenceLogic::update(const UsdPrim& prim, MObject parent, MObject refNode) const
+MStatus MayaReferenceLogic::update(const UsdPrim& prim, MObject parent) const
 {
-  // Check to see if we have a valid Maya reference attribute
-  UsdAttribute mayaReferenceAttribute = prim.GetAttribute(m_referenceName);
-  
-  SdfAssetPath mayaReferenceAssetPath;
-  mayaReferenceAttribute.Get(&mayaReferenceAssetPath);
-  MString mayaReferencePath(mayaReferenceAssetPath.GetResolvedPath().c_str());
-  
-  // Load file reference
-  std::string rigNamespace;
-  if(UsdAttribute rigNamespaceAttribute = prim.GetAttribute(m_namespaceName))
-  {
-    rigNamespaceAttribute.Get<std::string>(&rigNamespace);
-  }
-
   MStatus status;
-  MFnDependencyNode fnParent(parent, &status);
-  if(status)
-  {
-    if(status)
-    {
-      if (!refNode.isNull())
-      {
-        if (!refNode.hasFn(MFn::kReference))
-        {
-          MFnDependencyNode tempMfn(refNode, &status);
-          AL_MAYA_CHECK_ERROR(status, "MayaReferenceLogic::update given refNode was not a dependency node");
-          MGlobal::displayError("MayaReferenceLogic::update given refNode was not a reference: " + tempMfn.name());
-          return MStatus::kFailure;
-        }
-      }
-      else
-      {
-        MPlug messagePlug = fnParent.findPlug("message", &status);
-        MPlugArray referencePlugs;
-        messagePlug.connectedTo(referencePlugs, false, true);
-        for(uint32_t i = 0, n = referencePlugs.length(); i < n; ++i)
-        {
-          MObject temp = referencePlugs[i].node();
-          if(temp.hasFn(MFn::kReference))
-          {
-            refNode = temp;
-          }
-        }
-      }
-
-      MString command, filepath;
-      MFnReference fnReference(refNode);
-      command = MString("referenceQuery -f -withoutCopyNumber \"") + fnReference.name() + "\"";
-      MGlobal::executeCommand(command, filepath);
-      TF_DEBUG(ALUSDMAYA_TRANSLATORS).Msg("MayaReferenceLogic::update referenceNode=%s prim=%s execute \"%s\"=%s\n",
-#if MAYA_API_VERSION < 201700
-                                          fnReference.name().asChar(),
-#else
-                                          fnReference.absoluteName().asChar(),
-#endif
-                                          prim.GetPath().GetText(),
-                                          command.asChar(),
-                                          filepath.asChar());
-
-      if(prim.IsActive())
-      {
-        if(mayaReferencePath.length() != 0 && filepath != mayaReferencePath)
-        {
-          command = "file -loadReference \"";
-          command += fnReference.name();
-          command += "\" \"";
-          command += mayaReferencePath;
-          command += "\"";
-          TF_DEBUG(ALUSDMAYA_TRANSLATORS).Msg("MayaReferenceLogic::update prim=%s execute %s\n",
-                                              prim.GetPath().GetText(),
-                                              command.asChar());
-          status = MGlobal::executeCommand(command);
-          AL_MAYA_CHECK_ERROR(status, MString("Failed to update reference with new path: ") + mayaReferencePath);
-        }
-        else
-        {
-          // Check to see if reference is already loaded - if so, don't need to do anything!
-          if (fnReference.isLoaded())
-          {
-            TF_DEBUG(ALUSDMAYA_TRANSLATORS).Msg("MayaReferenceLogic::update prim=%s already loaded with correct path\n", prim.GetPath().GetText());
-          }
-          else
-          {
-            TF_DEBUG(ALUSDMAYA_TRANSLATORS).Msg("MayaReferenceLogic::update prim=%s loadReferenceByNode\n", prim.GetPath().GetText());
-            MString s = MFileIO::loadReferenceByNode(refNode, &status);
-          }
-
-          if(!rigNamespace.empty())
-          {
-            // check to see if the namespace has changed
-            MString refNamespace = fnReference.associatedNamespace(true);
-            TF_DEBUG(ALUSDMAYA_TRANSLATORS).Msg("MayaReferenceLogic::update prim=%s, namespace was: %s\n",
-                                                prim.GetPath().GetText(),
-                                                refNamespace.asChar());
-            if(refNamespace != rigNamespace.c_str())
-            {
-              command = "file -e -ns \"";
-              command += rigNamespace.c_str();
-              command += "\" \"";
-              command += filepath;
-              command += "\"";
-              TF_DEBUG(ALUSDMAYA_TRANSLATORS).Msg("MayaReferenceLogic::update prim=%s execute %s\n",
-                                                  prim.GetPath().GetText(),
-                                                  command.asChar());
-              if(!MGlobal::executeCommand(command))
-              {
-                MGlobal::displayError(MString("Failed to update reference with new namespace. refNS:" + refNamespace + "rigNs: " + rigNamespace.c_str() + ": ") + mayaReferencePath);
-              }
-            }
-          }
-        }
-      }
-      else
-      {
-        // Can unconditionally unload, as unloading an already unloaded reference
-        // won't do anything, and won't error
-        TF_DEBUG(ALUSDMAYA_TRANSLATORS).Msg("MayaReferenceLogic::update prim=%s unloadReferenceByNode\n", prim.GetPath().GetText());
-        MString s = MFileIO::unloadReferenceByNode(refNode, &status);
-      }
-    }
-  }
-  return MS::kSuccess;
-}
-
-//----------------------------------------------------------------------------------------------------------------------
-MStatus MayaReferenceLogic::LoadMayaReference(const UsdPrim& prim, MObject& parent, TranslatorContextPtr context) const
-{
-  TF_DEBUG(ALUSDMAYA_TRANSLATORS).Msg("MayaReferenceLogic::LoadMayaReference prim=%s\n", prim.GetPath().GetText());
-  const TfToken maya_associatedReferenceNode("maya_associatedReferenceNode");
-  MStatus status;
-
   SdfAssetPath mayaReferenceAssetPath;
   // Check to see if we have a valid Maya reference attribute
   UsdAttribute mayaReferenceAttribute = prim.GetAttribute(m_referenceName);
   mayaReferenceAttribute.Get(&mayaReferenceAssetPath);
   MString mayaReferencePath(mayaReferenceAssetPath.GetResolvedPath().c_str());
 
-  //The resolved path is empty if the maya reference is a full path.
+  // The resolved path is empty if the maya reference is a full path.
   if(!mayaReferencePath.length())
   {
     mayaReferencePath = mayaReferenceAssetPath.GetAssetPath().c_str();
   }
 
-  //If the path is still empty return, there is no reference to import
+  // If the path is still empty return, there is no reference to import
   if(!mayaReferencePath.length())
   {
     return MS::kFailure;
   }
 
-  // Load file reference
+  // Get required namespace attribute from prim
   std::string rigNamespace;
   if(UsdAttribute rigNamespaceAttribute = prim.GetAttribute(m_namespaceName))
   {
     if (!rigNamespaceAttribute.Get<std::string>(&rigNamespace))
     {
-        MGlobal::displayError(MString("Cannot load reference: Missing namespace on prim ") + MString(prim.GetPath().GetText()));
-        return MS::kFailure;
+      MGlobal::displayError(MString("Cannot load reference: Missing namespace on prim ") + MString(prim.GetPath().GetText()));
+      return MS::kFailure;
     }
   }
 
@@ -325,34 +193,146 @@ MStatus MayaReferenceLogic::LoadMayaReference(const UsdPrim& prim, MObject& pare
   MFnDagNode parentDag(parent, &status);
   AL_MAYA_CHECK_ERROR(status, "failed to attach function set to parent transform for reference.");
 
-  MObject referenceObject;
+  MObject refNode;
 
-  // Check to see if we already have a reference matching the prim's namespace.
-  for (MItDependencyNodes refIter(MFn::kReference); !refIter.isDone(); refIter.next())
+  // First, see if a reference is already attached
+  MFnDependencyNode fnParent(parent, &status);
+  if(status)
   {
-    referenceObject = refIter.item();
-    MFnReference tempRefFn(referenceObject);
-    if (!tempRefFn.isFromReferencedFile())
-    {
-      MPlug primNSPlug = tempRefFn.findPlug(MString(m_primNSAttr), true, &status);
-      if (status == MS::kInvalidParameter)
-      {
-        // No prim NS attribute. These aren't the droids we're looking for.
-        continue;
-      }
-
-      // Test the namespace
-      if (primNSPlug.asString() == rigNamespaceM)
-      {
-        // We found one with the same namespace - run an update instead of a load
-
-        // Reconnect the reference node's `associatedNode` attr before
-        // loading it, since the previous connection may be gone.
-        connectReferenceAssociatedNode(parentDag, tempRefFn);
-        return update(prim, parent, referenceObject);
+    MPlug messagePlug = fnParent.findPlug("message", &status);
+    MPlugArray referencePlugs;
+    messagePlug.connectedTo(referencePlugs, false, true);
+    for (uint32_t i = 0, n = referencePlugs.length(); i < n; ++i) {
+      MObject temp = referencePlugs[i].node();
+      if (temp.hasFn(MFn::kReference)) {
+        refNode = temp;
       }
     }
   }
+
+  // Check to see if we already have a reference matching the prim's namespace.
+  if(refNode.isNull())
+  {
+    for (MItDependencyNodes refIter(MFn::kReference); !refIter.isDone(); refIter.next()) {
+      MObject tempRefNode = refIter.item();
+      MFnReference tempRefFn(tempRefNode);
+      if (!tempRefFn.isFromReferencedFile()) {
+        MPlug primNSPlug = tempRefFn.findPlug(MString(m_primNSAttr), true, &status);
+        if (status == MS::kInvalidParameter) {
+          // No prim NS attribute. These aren't the droids we're looking for.
+          continue;
+        }
+
+        // Test the namespace
+        if (primNSPlug.asString() == rigNamespaceM) {
+          // We found one with the same namespace - continue running an update
+
+          // Reconnect the reference node's `associatedNode` attr before
+          // loading it, since the previous connection may be gone.
+          connectReferenceAssociatedNode(parentDag, tempRefFn);
+          refNode = tempRefNode;
+          break;
+        }
+      }
+    }
+  }
+
+  // If no reference found, we'll need to create it. This may be the first time we are
+  // bring in the reference or it may have been imported or removed directly in maya.
+  if (refNode.isNull())
+  {
+    return LoadMayaReference(prim, parent, mayaReferencePath, rigNamespaceM);
+  }
+
+  if(status)
+  {
+    MString command, filepath;
+    MFnReference fnReference(refNode);
+    command = MString("referenceQuery -f -withoutCopyNumber \"") + fnReference.name() + "\"";
+    MGlobal::executeCommand(command, filepath);
+    TF_DEBUG(ALUSDMAYA_TRANSLATORS).Msg("MayaReferenceLogic::update referenceNode=%s prim=%s execute \"%s\"=%s\n",
+#if MAYA_API_VERSION < 201700
+                                        fnReference.name().asChar(),
+#else
+                                        fnReference.absoluteName().asChar(),
+#endif
+                                        prim.GetPath().GetText(),
+                                        command.asChar(),
+                                        filepath.asChar());
+
+    if(prim.IsActive())
+    {
+      if(mayaReferencePath.length() != 0 && filepath != mayaReferencePath)
+      {
+        command = "file -loadReference \"";
+        command += fnReference.name();
+        command += "\" \"";
+        command += mayaReferencePath;
+        command += "\"";
+        TF_DEBUG(ALUSDMAYA_TRANSLATORS).Msg("MayaReferenceLogic::update prim=%s execute %s\n",
+                                            prim.GetPath().GetText(),
+                                            command.asChar());
+        status = MGlobal::executeCommand(command);
+        AL_MAYA_CHECK_ERROR(status, MString("Failed to update reference with new path: ") + mayaReferencePath);
+      }
+      else
+      {
+        // Check to see if reference is already loaded - if so, don't need to do anything!
+        if (fnReference.isLoaded())
+        {
+          TF_DEBUG(ALUSDMAYA_TRANSLATORS).Msg("MayaReferenceLogic::update prim=%s already loaded with correct path\n", prim.GetPath().GetText());
+        }
+        else
+        {
+          TF_DEBUG(ALUSDMAYA_TRANSLATORS).Msg("MayaReferenceLogic::update prim=%s loadReferenceByNode\n", prim.GetPath().GetText());
+          MString s = MFileIO::loadReferenceByNode(refNode, &status);
+        }
+
+        if(!rigNamespace.empty())
+        {
+          // check to see if the namespace has changed
+          MString refNamespace = fnReference.associatedNamespace(true);
+          TF_DEBUG(ALUSDMAYA_TRANSLATORS).Msg("MayaReferenceLogic::update prim=%s, namespace was: %s\n",
+                                              prim.GetPath().GetText(),
+                                              refNamespace.asChar());
+          if(refNamespace != rigNamespace.c_str())
+          {
+            command = "file -e -ns \"";
+            command += rigNamespace.c_str();
+            command += "\" \"";
+            command += filepath;
+            command += "\"";
+            TF_DEBUG(ALUSDMAYA_TRANSLATORS).Msg("MayaReferenceLogic::update prim=%s execute %s\n",
+                                                prim.GetPath().GetText(),
+                                                command.asChar());
+            if(!MGlobal::executeCommand(command))
+            {
+              MGlobal::displayError(MString("Failed to update reference with new namespace. refNS:" + refNamespace + "rigNs: " + rigNamespace.c_str() + ": ") + mayaReferencePath);
+            }
+          }
+        }
+      }
+    }
+    else
+    {
+      // Can unconditionally unload, as unloading an already unloaded reference
+      // won't do anything, and won't error
+      TF_DEBUG(ALUSDMAYA_TRANSLATORS).Msg("MayaReferenceLogic::update prim=%s unloadReferenceByNode\n", prim.GetPath().GetText());
+      MString s = MFileIO::unloadReferenceByNode(refNode, &status);
+    }
+  }
+  return MS::kSuccess;
+}
+
+//----------------------------------------------------------------------------------------------------------------------
+MStatus MayaReferenceLogic::LoadMayaReference(const UsdPrim& prim, MObject& parent, MString& mayaReferencePath, MString& rigNamespaceM) const
+{
+  TF_DEBUG(ALUSDMAYA_TRANSLATORS).Msg("MayaReferenceLogic::LoadMayaReference prim=%s\n", prim.GetPath().GetText());
+  const TfToken maya_associatedReferenceNode("maya_associatedReferenceNode");
+  MStatus status;
+
+  MFnDagNode parentDag(parent, &status);
+  AL_MAYA_CHECK_ERROR(status, "failed to attach function set to parent transform for reference.");
 
   // Need to create new reference (initially unloaded).
   MStringArray createdNodes;
@@ -379,6 +359,7 @@ MStatus MayaReferenceLogic::LoadMayaReference(const UsdPrim& prim, MObject& pare
   }
 
   // Retrieve created reference node
+  MObject referenceObject;
   MString refNode = createdNodes[0];
   MSelectionList selectionList;
   selectionList.add(refNode);

--- a/translators/MayaReference.h
+++ b/translators/MayaReference.h
@@ -33,9 +33,9 @@ class MayaReferenceLogic
 {
 public:
 
-  MStatus LoadMayaReference(const UsdPrim& prim, MObject& parent, TranslatorContextPtr context) const;
+  MStatus LoadMayaReference(const UsdPrim& prim, MObject& parent, MString& mayaReferencePath, MString& rigNamespaceM) const;
   MStatus UnloadMayaReference(MObject& parent) const;
-  MStatus update(const UsdPrim& prim, MObject parent, MObject refNode=MObject::kNullObj) const;
+  MStatus update(const UsdPrim& prim, MObject parent) const;
 
 private:
   MStatus connectReferenceAssociatedNode(MFnDagNode& dagNode, MFnReference& refNode) const;


### PR DESCRIPTION
## Description
Combine the similar logic from update() and LoadMayaReference() to make the maya reference translator more resilient to imported references and stage changes.

The main change is just a reordering of the logic. I consolidated the logic for finding the reference node into update() and only call "LoadMayaReference" if we need to create a fresh reference. update() becomes the main entry point for initial creation and updating and holds all the logic for what to do. I didn't see any good reason for the code paths to be different and it meant that some situations were not handled in one versus the other.

### Fixed
- If multiple object changed notices pile up for a maya reference prim instead of bringing in the reference multiple times, it will only bring it in once.
- If a reference is imported, the proxy shape will bring in a fresh reference the next time the proxy shape is resynced if the prim is still active. (This is especially desirable for our asset manager which we use to bring in references. If an artist imports a ref, it "severs" the connection to the stage and a new reference is brought in if requested) 

## Checklist (Please do not remove this line)
- [x] Make sure the Title and Description of the PR make sense and  provide sufficient context for your work
- [x] Do any added files have the correct AL Apache Licence Header?
- [x] Are there Doxygen comments in the headers?
- [x] Are any new features, behaviour changes documented in the .md format [documentation](https://github.com/AnimalLogic/AL_USDMaya/docs)?
- [x] Have you added, updated tests to cover new features and behaviour changes?
- [x] Have you filled out at least one changelog entry?
