### PR TITLE
ufe selection: check for correct proxy shape before drawing sel highlight

### DIFF
--- a/lib/AL_USDMaya/AL/usdmaya/nodes/ProxyDrawOverride.cpp
+++ b/lib/AL_USDMaya/AL/usdmaya/nodes/ProxyDrawOverride.cpp
@@ -415,15 +415,22 @@ void ProxyDrawOverride::draw(const MHWRender::MDrawContext& context, const MUser
 		// Draw selection highlighting for all USD items in the UFE selection.
         SdfPathVector ufePaths;
         auto ufeSelList = Ufe::GlobalSelection::get();
+
+        Ufe::PathSegment proxyUfePath = ptr->m_shape->ufePathSegment();
         for (const auto& sceneItem : *ufeSelList)
         {
             if (sceneItem->runTimeId() == USD_UFE_RUNTIME_ID)
             {
                 const Ufe::Path& itemPath = sceneItem->path();
-                Ufe::PathSegment leaf = itemPath.getSegments().back();
-                if (leaf.runTimeId() == USD_UFE_RUNTIME_ID)
+                const Ufe::PathSegment& usdPathSegment = itemPath.getSegments().back();
+                if (usdPathSegment.runTimeId() == USD_UFE_RUNTIME_ID
+                    && itemPath.getSegments().size() == 2)
                 {
-                    ufePaths.emplace_back(leaf.string());
+                  const Ufe::PathSegment& mayaPathSegment = itemPath.getSegments().front();
+                  if(mayaPathSegment == proxyUfePath)
+                  {
+                    ufePaths.emplace_back(usdPathSegment.string());
+                  }
                 }
             }
         }

--- a/lib/AL_USDMaya/AL/usdmaya/nodes/ProxyShape.cpp
+++ b/lib/AL_USDMaya/AL/usdmaya/nodes/ProxyShape.cpp
@@ -2206,7 +2206,7 @@ MSelectionMask ProxyShape::getShapeSelectionMask() const
 
 #if defined(WANT_UFE_BUILD)
 //----------------------------------------------------------------------------------------------------------------------
-Ufe::Path ProxyShape::ufePath() const
+Ufe::PathSegment ProxyShape::ufePathSegment() const
 {
     //Build a path segment to proxyShape
     MDagPath thisPath;
@@ -2215,7 +2215,13 @@ Ufe::Path ProxyShape::ufePath() const
     // MDagPath does not include |world to its full path naem
     MString fullpath = "|world" + thisPath.fullPathName();
 
-    return Ufe::Path(Ufe::PathSegment(fullpath.asChar(), MAYA_UFE_RUNTIME_ID, MAYA_UFE_SEPARATOR));
+    return Ufe::PathSegment(fullpath.asChar(), MAYA_UFE_RUNTIME_ID, MAYA_UFE_SEPARATOR);
+}
+
+
+Ufe::Path ProxyShape::ufePath() const
+{
+    return Ufe::Path(ProxyShape::ufePathSegment());
 }
 #endif
 

--- a/lib/AL_USDMaya/AL/usdmaya/nodes/ProxyShape.h
+++ b/lib/AL_USDMaya/AL/usdmaya/nodes/ProxyShape.h
@@ -50,8 +50,10 @@
 
 #if defined(WANT_UFE_BUILD)
 #include "ufe/ufe.h"
+
 UFE_NS_DEF {
     class Path;
+    class PathSegment;
 }
 #endif
 
@@ -860,6 +862,11 @@ public:
   /// \return An UFE path containing the path to the proxy shape
   AL_USDMAYA_PUBLIC
   Ufe::Path ufePath() const;
+
+  /// \brief Get the UFE path segment of the maya proxy shape
+  /// \return An UFE path segment containing the maya path to the proxy shape
+  AL_USDMAYA_PUBLIC
+  Ufe::PathSegment ufePathSegment() const;
 #endif
 
   /// \brief  Returns the selection mask of the shape


### PR DESCRIPTION
## Description (this won't be part of the changelog)
When using UFE selection, this fixes drawing of the selection by checking the proxy shape

otherwise, if you have 20 proxy shapes, all pointing at the same usd,
then select an item in one, that item will be highlighted in all 20

## Changelog
### Fixed
- ufe selection: check for correct proxy shape before drawing sel highlight

## Checklist (Please do not remove this line)
- [X] Make sure the Title and Description of the PR make sense and  provide sufficient context for your work
- [X] Do any added files have the correct AL Apache Licence Header?
- [X] Are there Doxygen comments in the headers?
- [X] Are any new features, behaviour changes documented in the .md format [documentation](https://github.com/AnimalLogic/AL_USDMaya/docs)?
- [ ] Have you added, updated tests to cover new features and behaviour changes?
- [X] Have you filled out at least one changelog entry?
