### PR TITLE
fix variant switch refresh bug

### DIFF
--- a/lib/AL_USDMaya/AL/usdmaya/nodes/ProxyShape.cpp
+++ b/lib/AL_USDMaya/AL/usdmaya/nodes/ProxyShape.cpp
@@ -1143,6 +1143,9 @@ void ProxyShape::onObjectsChanged(UsdNotice::ObjectsChanged const& notice, UsdSt
   {
     constructLockPrims();
   }
+
+  // Manually trigger a viewport redraw
+  MGlobal::executeCommand("refresh");
 }
 
 //----------------------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
## Description
Adds a Maya refresh command call after objects change (variant switch) in order to trigger a viewport redraw

## Changelog

### Changed
Refresh command call added at the end of ProxyShape::onObjectsChanged

## Checklist (Please do not remove this line)
- [x] Make sure the Title and Description of the PR make sense and  provide sufficient context for your work
- [ ] Do any added files have the correct AL Apache Licence Header?
- [ ] Are there Doxygen comments in the headers?
- [ ] Are any new features, behaviour changes documented in the .md format [documentation](https://github.com/AnimalLogic/AL_USDMaya/docs)?
- [ ] Have you added, updated tests to cover new features and behaviour changes?
- [x] Have you filled out at least one changelog entry?
