### PR TITLE
Fixes a crash that happens when using AL_usdmayaProxyShapeSelect with pseudo-root "/"

### DIFF
--- a/lib/AL_USDMaya/AL/usdmaya/nodes/ProxyShapeSelection.cpp
+++ b/lib/AL_USDMaya/AL/usdmaya/nodes/ProxyShapeSelection.cpp
@@ -1050,6 +1050,20 @@ bool ProxyShape::doSelect(SelectionUndoHelper& helper, const SdfPathVector& orde
   }
   MStringArray newlySelectedPaths;
 
+  auto removeFromMSel = [](MSelectionList& sel, const MObject& toRemove) -> bool {
+    for(uint32_t i = 0, n = sel.length(); i < n; ++i)
+    {
+      MObject obj;
+      sel.getDependNode(i, obj);
+      if(obj == toRemove)
+      {
+        sel.remove(i);
+        return true;
+      }
+    }
+    return false;
+  };
+
   switch(helper.m_mode)
   {
   case MGlobal::kReplaceList:
@@ -1084,6 +1098,14 @@ bool ProxyShape::doSelect(SelectionUndoHelper& helper, const SdfPathVector& orde
       uint32_t hasNodesToCreate = 0;
       for(auto prim : insertPrims)
       {
+        if(prim.IsPseudoRoot())
+        {
+          // For pseudo root, just modify maya's selection, don't alter
+          // our internal paths
+          newlySelectedPaths.append(MFnDagNode(thisMObject()).fullPathName());
+          addObjToSelectionList(helper.m_newSelection, thisMObject());
+          continue;
+        }
         m_selectedPaths.insert(prim.GetPath());
         MString pathName;
         MObject object = makeUsdTransformChain_internal(prim, helper.m_modifier1, ProxyShape::kSelection, &helper.m_modifier2, &hasNodesToCreate, &pathName);
@@ -1136,6 +1158,19 @@ bool ProxyShape::doSelect(SelectionUndoHelper& helper, const SdfPathVector& orde
       uint32_t hasNodesToCreate = 0;
       for(auto prim : prims)
       {
+        if(prim.IsPseudoRoot())
+        {
+          // For pseudo root, just modify maya's selection
+          // However, since we don't want the pseudo root to "pollute" our
+          // internal selected paths, we also need to make sure we clear
+          // it from m_paths.  (We don't need to do those in other modes,
+          // because those set m_paths to m_selectePaths).
+          newlySelectedPaths.append(MFnDagNode(thisMObject()).fullPathName());
+          addObjToSelectionList(helper.m_newSelection, thisMObject());
+          helper.m_paths.erase(prim.GetPath());
+          continue;
+        }
+
         m_selectedPaths.insert(prim.GetPath());
         MString pathName;
         MObject object = makeUsdTransformChain_internal(prim, helper.m_modifier1, ProxyShape::kSelection, &helper.m_modifier2, &hasNodesToCreate, &pathName);
@@ -1158,7 +1193,16 @@ bool ProxyShape::doSelect(SelectionUndoHelper& helper, const SdfPathVector& orde
       // newlySelectedPaths - which is not altered in this branch
       for(auto path : helper.m_paths)
       {
-        bool alreadySelected = m_selectedPaths.count(path) > 0;
+        bool alreadySelected;
+        if(path == SdfPath::AbsoluteRootPath())
+        {
+          // For pseudo-root, remove proxy shape from maya's selection
+          alreadySelected = removeFromMSel(helper.m_newSelection, thisMObject());
+        }
+        else
+        {
+          alreadySelected = m_selectedPaths.count(path) > 0;
+        }
 
         if(alreadySelected)
         {
@@ -1180,23 +1224,20 @@ bool ProxyShape::doSelect(SelectionUndoHelper& helper, const SdfPathVector& orde
 
       for(auto prim : prims)
       {
+        if(prim.IsPseudoRoot())
+        {
+          // We've already removed this when iterating helper.m_paths,
+          // we just added to prims so the "prims.empty" early-exit test wouldn't
+          // fire
+          continue;
+        }
         auto temp = m_requiredPaths.find(prim.GetPath());
         MObject object = temp->second.node();
 
         m_selectedPaths.erase(prim.GetPath());
 
         removeUsdTransformChain_internal(prim, helper.m_modifier1, ProxyShape::kSelection);
-        for(uint32_t i = 0; i < helper.m_newSelection.length(); ++i)
-        {
-          MObject obj;
-          helper.m_newSelection.getDependNode(i, obj);
-
-          if(object == obj)
-          {
-            helper.m_newSelection.remove(i);
-            break;
-          }
-        }
+        removeFromMSel(helper.m_newSelection, object);
         helper.m_removedRefs.emplace_back(prim.GetPath(), object);
       }
       helper.m_paths = m_selectedPaths;
@@ -1209,7 +1250,16 @@ bool ProxyShape::doSelect(SelectionUndoHelper& helper, const SdfPathVector& orde
       std::vector<UsdPrim> insertPrims;
       for(auto path : orderedPaths)
       {
-        bool alreadySelected = m_selectedPaths.count(path) > 0;
+        bool alreadySelected;
+        if(path == SdfPath::AbsoluteRootPath())
+        {
+          // For pseudo-root, remove proxy shape from maya's selection
+          alreadySelected = removeFromMSel(helper.m_newSelection, thisMObject());
+        }
+        else
+        {
+          alreadySelected = m_selectedPaths.count(path) > 0;
+        }
 
         auto prim = stage->GetPrimAtPath(path);
         if(prim)
@@ -1232,29 +1282,34 @@ bool ProxyShape::doSelect(SelectionUndoHelper& helper, const SdfPathVector& orde
 
       for(auto prim : removePrims)
       {
+        if(prim.IsPseudoRoot())
+        {
+          // We've already removed this when iterating orderedPaths,
+          // we just added to removePrims so the "removePrims.empty" early-exit test
+          // wouldn't fire
+          continue;
+        }
         auto temp = m_requiredPaths.find(prim.GetPath());
         MObject object = temp->second.node();
 
         m_selectedPaths.erase(prim.GetPath());
 
         removeUsdTransformChain_internal(prim, helper.m_modifier1, ProxyShape::kSelection);
-        for(uint32_t i = 0; i < helper.m_newSelection.length(); ++i)
-        {
-          MObject obj;
-          helper.m_newSelection.getDependNode(i, object);
-
-          if(object == obj)
-          {
-            helper.m_newSelection.remove(i);
-            break;
-          }
-        }
+        removeFromMSel(helper.m_newSelection, object);
         helper.m_removedRefs.emplace_back(prim.GetPath(), object);
       }
 
       uint32_t hasNodesToCreate = 0;
       for(auto prim : insertPrims)
       {
+        if(prim.IsPseudoRoot())
+        {
+          // For pseudo root, just modify maya's selection, don't alter
+          // our internal paths
+          newlySelectedPaths.append(MFnDagNode(thisMObject()).fullPathName());
+          addObjToSelectionList(helper.m_newSelection, thisMObject());
+          continue;
+        }
         m_selectedPaths.insert(prim.GetPath());
         MString pathName;
         MObject object = makeUsdTransformChain_internal(prim, helper.m_modifier1, ProxyShape::kSelection, &helper.m_modifier2, &hasNodesToCreate, &pathName);

--- a/plugin/AL_USDMayaTestPlugin/AL/usdmaya/commands/test_ProxyShapeSelect.cpp
+++ b/plugin/AL_USDMayaTestPlugin/AL/usdmaya/commands/test_ProxyShapeSelect.cpp
@@ -255,7 +255,6 @@ TEST(ProxyShapeSelect, selectNode1)
   EXPECT_FALSE(proxy->isRequiredPath(SdfPath("/root/hip1/knee1/ankle1/ltoe1")));
   MGlobal::getActiveSelectionList(sl);
   EXPECT_EQ(0, sl.length());
-
 }
 
 
@@ -1268,3 +1267,279 @@ TEST(ProxyShapeSelect, deselectNode)
   assertNothingSelected();
 
 }
+
+TEST(ProxyShapeSelect, pseudoRootSelect)
+{
+  MFileIO::newFile(true);
+  // unsure undo is enabled for this test
+  MGlobal::executeCommand("undoInfo -state 1;");
+
+  auto constructTransformChain = [] ()
+  {
+    UsdStageRefPtr stage = UsdStage::CreateInMemory();
+
+    UsdGeomXform root = UsdGeomXform::Define(stage, SdfPath("/root"));
+    UsdGeomXform leg1 = UsdGeomXform::Define(stage, SdfPath("/root/hip1"));
+    UsdGeomXform knee1 = UsdGeomXform::Define(stage, SdfPath("/root/hip1/knee1"));
+    UsdGeomXform ankle1 = UsdGeomXform::Define(stage, SdfPath("/root/hip1/knee1/ankle1"));
+    UsdGeomXform rtoe1 = UsdGeomXform::Define(stage, SdfPath("/root/hip1/knee1/ankle1/ltoe1"));
+    UsdGeomXform ltoe1 = UsdGeomXform::Define(stage, SdfPath("/root/hip1/knee1/ankle1/rtoe1"));
+    UsdGeomXform leg2 = UsdGeomXform::Define(stage, SdfPath("/root/hip2"));
+    UsdGeomXform knee2 = UsdGeomXform::Define(stage, SdfPath("/root/hip2/knee2"));
+    UsdGeomXform ankle2 = UsdGeomXform::Define(stage, SdfPath("/root/hip2/knee2/ankle2"));
+    UsdGeomXform rtoe2 = UsdGeomXform::Define(stage, SdfPath("/root/hip2/knee2/ankle2/ltoe2"));
+    UsdGeomXform ltoe2 = UsdGeomXform::Define(stage, SdfPath("/root/hip2/knee2/ankle2/rtoe2"));
+
+    return stage;
+  };
+
+  auto compareNodes = [] (const SdfPathVector& paths)
+  {
+    MSelectionList sl;
+    MGlobal::getActiveSelectionList(sl);
+    EXPECT_EQ(sl.length(), paths.size());
+    for(uint32_t i = 0; i < sl.length(); ++i)
+    {
+      MObject obj;
+      sl.getDependNode(i, obj);
+      MFnDependencyNode fn(obj);
+      MString pathName;
+      if (fn.typeId() == AL::usdmaya::nodes::ProxyShape::kTypeId)
+      {
+        EXPECT_EQ(MString("|transform1|AL_usdmaya_ProxyShape1"),
+            MFnDagNode(obj).fullPathName());
+        pathName = "/";
+      }
+      else
+      {
+        MStatus status;
+        MPlug plug = fn.findPlug("primPath", &status);
+        EXPECT_EQ(MStatus(MS::kSuccess), status);
+        pathName = plug.asString();
+      }
+      bool found = false;
+      for(uint32_t j = 0; j < paths.size(); ++j)
+      {
+        if(pathName == paths[j].GetText())
+        {
+          found = true;
+          break;
+        }
+      }
+      EXPECT_TRUE(found);
+    }
+  };
+
+  const std::string temp_path = buildTempPath("AL_USDMayaTests_selectNode.usda");
+  std::string sessionLayerContents;
+
+
+  // generate some data for the proxy shape
+  {
+    auto stage = constructTransformChain();
+    stage->Export(temp_path, false);
+  }
+
+  MFnDagNode fn;
+  MObject xform = fn.create("transform");
+  MObject shape = fn.create("AL_usdmaya_ProxyShape", xform);
+  MString shapeName = fn.name();
+
+  AL::usdmaya::nodes::ProxyShape* proxy = (AL::usdmaya::nodes::ProxyShape*)fn.userNode();
+
+  // force the stage to load
+  proxy->filePathPlug().setString(temp_path.c_str());
+
+  MStringArray results;
+
+  // select the root of the usd stage. No transforms should be generated, but the proxy shape
+  // itself should be selected.
+  MGlobal::executeCommand("select -cl;");
+
+  // State 0: nothing selected
+
+  MGlobal::executeCommand("AL_usdmaya_ProxyShapeSelect -r -pp \"/\" \"AL_usdmaya_ProxyShape1\"", results, false, true);
+  EXPECT_EQ(1, results.length());
+  EXPECT_EQ(MString("|transform1|AL_usdmaya_ProxyShape1"), results[0]);
+  results.clear();
+
+  // State 1: proxy selected
+  // make sure nothing is in the internally selected paths
+  EXPECT_EQ(0, proxy->selectedPaths().size());
+  // Make sure active selection is as expected
+  { SCOPED_TRACE(""); compareNodes({SdfPath("/")}); };
+
+  // make sure undo clears the previous info
+  MGlobal::executeCommand("undo", false, true);
+
+  // State 0: nothing selected
+  EXPECT_EQ(0, proxy->selectedPaths().size());
+  { SCOPED_TRACE(""); compareNodes({}); };
+
+  // make sure redo works happily without side effects
+  MGlobal::executeCommand("redo", false, true);
+
+  // State 1: proxy selected
+  EXPECT_EQ(0, proxy->selectedPaths().size());
+  { SCOPED_TRACE(""); compareNodes({SdfPath("/")}); };
+
+  // Make sure toggle works with a root path, and another path
+  MGlobal::executeCommand("AL_usdmaya_ProxyShapeSelect -r -tgl -pp \"/root/hip1/knee1/ankle1/ltoe1\" -pp \"/\" \"AL_usdmaya_ProxyShape1\"", results, false, true);
+  EXPECT_EQ(MString("|transform1|root|hip1|knee1|ankle1|ltoe1"), results[0]);
+  results.clear();
+
+  // State 2: ltoe1 selected
+  // make sure ltoe1 is contained in the selected paths (for hydra selection)
+  EXPECT_EQ(1, proxy->selectedPaths().size());
+  EXPECT_EQ(1, proxy->selectedPaths().count(SdfPath("/root/hip1/knee1/ankle1/ltoe1")));
+  EXPECT_TRUE(proxy->isRequiredPath(SdfPath("/root")));
+  EXPECT_TRUE(proxy->isRequiredPath(SdfPath("/root/hip1")));
+  EXPECT_TRUE(proxy->isRequiredPath(SdfPath("/root/hip1/knee1")));
+  EXPECT_TRUE(proxy->isRequiredPath(SdfPath("/root/hip1/knee1/ankle1")));
+  EXPECT_TRUE(proxy->isRequiredPath(SdfPath("/root/hip1/knee1/ankle1/ltoe1")));
+  // Ensure the proxyShape is no longer selected, and the other sub-path is
+  { SCOPED_TRACE(""); compareNodes({SdfPath("/root/hip1/knee1/ankle1/ltoe1")}); };
+
+  // Make sure append works
+  MGlobal::executeCommand("AL_usdmaya_ProxyShapeSelect -append -pp \"/\" -pp \"/root/hip2\" \"AL_usdmaya_ProxyShape1\"", results, false, true);
+  EXPECT_EQ(2, results.length());
+  EXPECT_EQ(MString("|transform1|AL_usdmaya_ProxyShape1"), results[0]);
+  EXPECT_EQ(MString("|transform1|root|hip2"), results[1]);
+  results.clear();
+
+  // State 3: ltoe1, proxy, hip2 selected
+  // make sure ltoe1 and hip2 are contained in the selected paths (for hydra selection)
+  EXPECT_EQ(2, proxy->selectedPaths().size());
+  EXPECT_EQ(1, proxy->selectedPaths().count(SdfPath("/root/hip1/knee1/ankle1/ltoe1")));
+  EXPECT_EQ(1, proxy->selectedPaths().count(SdfPath("/root/hip2")));
+  EXPECT_TRUE(proxy->isRequiredPath(SdfPath("/root")));
+  EXPECT_TRUE(proxy->isRequiredPath(SdfPath("/root/hip1")));
+  EXPECT_TRUE(proxy->isRequiredPath(SdfPath("/root/hip1/knee1")));
+  EXPECT_TRUE(proxy->isRequiredPath(SdfPath("/root/hip1/knee1/ankle1")));
+  EXPECT_TRUE(proxy->isRequiredPath(SdfPath("/root/hip1/knee1/ankle1/ltoe1")));
+  EXPECT_TRUE(proxy->isRequiredPath(SdfPath("/root/hip2")));
+  // Ensure the proxyShape is selected again, as well as ltoe2 and hip2
+  { SCOPED_TRACE(""); compareNodes({SdfPath("/root/hip1/knee1/ankle1/ltoe1"), SdfPath("/"), SdfPath("/root/hip2")}); };
+
+  // Make sure remove works
+  MGlobal::executeCommand("AL_usdmaya_ProxyShapeSelect -d -pp \"/\" \"AL_usdmaya_ProxyShape1\"", results, false, true);
+  EXPECT_EQ(0, results.length());
+
+  // State 4: ltoe1, hip2 selected
+  // make sure ltoe1 and hip2 are contained in the selected paths (for hydra selection)
+  EXPECT_EQ(2, proxy->selectedPaths().size());
+  EXPECT_EQ(1, proxy->selectedPaths().count(SdfPath("/root/hip1/knee1/ankle1/ltoe1")));
+  EXPECT_EQ(1, proxy->selectedPaths().count(SdfPath("/root/hip2")));
+  EXPECT_TRUE(proxy->isRequiredPath(SdfPath("/root")));
+  EXPECT_TRUE(proxy->isRequiredPath(SdfPath("/root/hip1")));
+  EXPECT_TRUE(proxy->isRequiredPath(SdfPath("/root/hip1/knee1")));
+  EXPECT_TRUE(proxy->isRequiredPath(SdfPath("/root/hip1/knee1/ankle1")));
+  EXPECT_TRUE(proxy->isRequiredPath(SdfPath("/root/hip1/knee1/ankle1/ltoe1")));
+  EXPECT_TRUE(proxy->isRequiredPath(SdfPath("/root/hip2")));
+  // Ensure the proxyShape is no longer selected
+  { SCOPED_TRACE(""); compareNodes({SdfPath("/root/hip1/knee1/ankle1/ltoe1"), SdfPath("/root/hip2")}); };
+
+  // Undo the remove
+  MGlobal::executeCommand("undo", false, true);
+
+  // State 3: ltoe1, proxy, hip2 selected
+  // make sure ltoe1 and hip2 are contained in the selected paths (for hydra selection)
+  EXPECT_EQ(2, proxy->selectedPaths().size());
+  EXPECT_EQ(1, proxy->selectedPaths().count(SdfPath("/root/hip1/knee1/ankle1/ltoe1")));
+  EXPECT_EQ(1, proxy->selectedPaths().count(SdfPath("/root/hip2")));
+  EXPECT_TRUE(proxy->isRequiredPath(SdfPath("/root")));
+  EXPECT_TRUE(proxy->isRequiredPath(SdfPath("/root/hip1")));
+  EXPECT_TRUE(proxy->isRequiredPath(SdfPath("/root/hip1/knee1")));
+  EXPECT_TRUE(proxy->isRequiredPath(SdfPath("/root/hip1/knee1/ankle1")));
+  EXPECT_TRUE(proxy->isRequiredPath(SdfPath("/root/hip1/knee1/ankle1/ltoe1")));
+  EXPECT_TRUE(proxy->isRequiredPath(SdfPath("/root/hip2")));
+  // Ensure the proxyShape is selected again, as well as ltoe2 and hip2
+  { SCOPED_TRACE(""); compareNodes({SdfPath("/root/hip1/knee1/ankle1/ltoe1"), SdfPath("/"), SdfPath("/root/hip2")}); };
+
+  // Undo the append
+  MGlobal::executeCommand("undo", false, true);
+
+  // State 2: ltoe1 selected
+  // make sure ltoe1 is contained in the selected paths (for hydra selection)
+  EXPECT_EQ(1, proxy->selectedPaths().size());
+  EXPECT_EQ(1, proxy->selectedPaths().count(SdfPath("/root/hip1/knee1/ankle1/ltoe1")));
+  EXPECT_TRUE(proxy->isRequiredPath(SdfPath("/root")));
+  EXPECT_TRUE(proxy->isRequiredPath(SdfPath("/root/hip1")));
+  EXPECT_TRUE(proxy->isRequiredPath(SdfPath("/root/hip1/knee1")));
+  EXPECT_TRUE(proxy->isRequiredPath(SdfPath("/root/hip1/knee1/ankle1")));
+  EXPECT_TRUE(proxy->isRequiredPath(SdfPath("/root/hip1/knee1/ankle1/ltoe1")));
+  // Ensure the proxyShape is no longer selected, and the other sub-path is
+  { SCOPED_TRACE(""); compareNodes({SdfPath("/root/hip1/knee1/ankle1/ltoe1")}); };
+
+  // Undo the toggle
+  MGlobal::executeCommand("undo", false, true);
+
+  // State 1: proxy selected
+  EXPECT_EQ(0, proxy->selectedPaths().size());
+  { SCOPED_TRACE(""); compareNodes({SdfPath("/")}); };
+
+  // Undo the initial replace
+  MGlobal::executeCommand("undo", false, true);
+
+  // State 0: nothing selected
+  EXPECT_EQ(0, proxy->selectedPaths().size());
+  { SCOPED_TRACE(""); compareNodes({}); };
+
+  // Redo the initial replace
+  MGlobal::executeCommand("redo", false, true);
+
+  // State 1: proxy selected
+  EXPECT_EQ(0, proxy->selectedPaths().size());
+  { SCOPED_TRACE(""); compareNodes({SdfPath("/")}); };
+
+  // Redo the toggle
+  MGlobal::executeCommand("redo", false, true);
+
+  // State 2: ltoe1 selected
+  // make sure ltoe1 is contained in the selected paths (for hydra selection)
+  EXPECT_EQ(1, proxy->selectedPaths().size());
+  EXPECT_EQ(1, proxy->selectedPaths().count(SdfPath("/root/hip1/knee1/ankle1/ltoe1")));
+  EXPECT_TRUE(proxy->isRequiredPath(SdfPath("/root")));
+  EXPECT_TRUE(proxy->isRequiredPath(SdfPath("/root/hip1")));
+  EXPECT_TRUE(proxy->isRequiredPath(SdfPath("/root/hip1/knee1")));
+  EXPECT_TRUE(proxy->isRequiredPath(SdfPath("/root/hip1/knee1/ankle1")));
+  EXPECT_TRUE(proxy->isRequiredPath(SdfPath("/root/hip1/knee1/ankle1/ltoe1")));
+  // Ensure the proxyShape is no longer selected, and the other sub-path is
+  { SCOPED_TRACE(""); compareNodes({SdfPath("/root/hip1/knee1/ankle1/ltoe1")}); };
+
+  // Redo the append
+  MGlobal::executeCommand("redo", false, true);
+
+  // State 3: ltoe1, proxy, hip2 selected
+  // make sure ltoe1 and hip2 are contained in the selected paths (for hydra selection)
+  EXPECT_EQ(2, proxy->selectedPaths().size());
+  EXPECT_EQ(1, proxy->selectedPaths().count(SdfPath("/root/hip1/knee1/ankle1/ltoe1")));
+  EXPECT_EQ(1, proxy->selectedPaths().count(SdfPath("/root/hip2")));
+  EXPECT_TRUE(proxy->isRequiredPath(SdfPath("/root")));
+  EXPECT_TRUE(proxy->isRequiredPath(SdfPath("/root/hip1")));
+  EXPECT_TRUE(proxy->isRequiredPath(SdfPath("/root/hip1/knee1")));
+  EXPECT_TRUE(proxy->isRequiredPath(SdfPath("/root/hip1/knee1/ankle1")));
+  EXPECT_TRUE(proxy->isRequiredPath(SdfPath("/root/hip1/knee1/ankle1/ltoe1")));
+  EXPECT_TRUE(proxy->isRequiredPath(SdfPath("/root/hip2")));
+  // Ensure the proxyShape is selected again, as well as ltoe2 and hip2
+  { SCOPED_TRACE(""); compareNodes({SdfPath("/root/hip1/knee1/ankle1/ltoe1"), SdfPath("/"), SdfPath("/root/hip2")}); };
+
+  // Redo the remove
+  MGlobal::executeCommand("redo", false, true);
+
+  // State 4: ltoe1, hip2 selected
+  // make sure ltoe1 and hip2 are contained in the selected paths (for hydra selection)
+  EXPECT_EQ(2, proxy->selectedPaths().size());
+  EXPECT_EQ(1, proxy->selectedPaths().count(SdfPath("/root/hip1/knee1/ankle1/ltoe1")));
+  EXPECT_EQ(1, proxy->selectedPaths().count(SdfPath("/root/hip2")));
+  EXPECT_TRUE(proxy->isRequiredPath(SdfPath("/root")));
+  EXPECT_TRUE(proxy->isRequiredPath(SdfPath("/root/hip1")));
+  EXPECT_TRUE(proxy->isRequiredPath(SdfPath("/root/hip1/knee1")));
+  EXPECT_TRUE(proxy->isRequiredPath(SdfPath("/root/hip1/knee1/ankle1")));
+  EXPECT_TRUE(proxy->isRequiredPath(SdfPath("/root/hip1/knee1/ankle1/ltoe1")));
+  EXPECT_TRUE(proxy->isRequiredPath(SdfPath("/root/hip2")));
+  // Ensure the proxyShape is no longer selected
+  { SCOPED_TRACE(""); compareNodes({SdfPath("/root/hip1/knee1/ankle1/ltoe1"), SdfPath("/root/hip2")}); };
+}
+
+


### PR DESCRIPTION
## Description (this won't be part of the changelog)

NOTE: this branches off of https://github.com/AnimalLogic/AL_USDMaya/pull/142, so please check that PR first.

Currently, if you try to use the AL_usdmayaProxyShapeSelect command to select the pseudo-root ("/"), it will trigger a crash. (Though sometimes not immediately.)  This fixes this, so that trying to select the root will just select the ProxyShape object itself, instead.

## Changelog
### Fixed
- Fixes crash when selecting "/" with AL_usdmayaProxyShapeSelect; now selects proxy shape object

## Checklist (Please do not remove this line)
- [X] Make sure the Title and Description of the PR make sense and  provide sufficient context for your work
- [X] Do any added files have the correct AL Apache Licence Header?
- [X] Are there Doxygen comments in the headers?
- [X] Are any new features, behaviour changes documented in the .md format [documentation](https://github.com/AnimalLogic/AL_USDMaya/docs)?
- [X] Have you added, updated tests to cover new features and behaviour changes?
- [X] Have you filled out at least one changelog entry?
