### PR TITLE
fix issue where proxy shape wasn't redrawn when filepath was changed

### DIFF
--- a/lib/AL_USDMaya/AL/usdmaya/Global.cpp
+++ b/lib/AL_USDMaya/AL/usdmaya/Global.cpp
@@ -373,7 +373,6 @@ static void postFileRead(void*)
       proxy->deserialiseTranslatorContext();
       proxy->findTaggedPrims();
       proxy->deserialiseTransformRefs();
-      proxy->constructGLImagingEngine();
     }
     unloadedProxies.clear();
   }

--- a/lib/AL_USDMaya/AL/usdmaya/nodes/ProxyDrawOverride.cpp
+++ b/lib/AL_USDMaya/AL/usdmaya/nodes/ProxyDrawOverride.cpp
@@ -62,7 +62,6 @@ public:
 
   UsdImagingGLRenderParams m_params;
   UsdPrim m_rootPrim;
-  Engine* m_engine = 0;
   ProxyShape* m_shape = 0;
   MDagPath m_objPath;
 };
@@ -137,10 +136,7 @@ MUserData* ProxyDrawOverride::prepareForDraw(
   auto engine = shape->engine();
   if(!engine)
   {
-    shape->constructGLImagingEngine();
-    engine = shape->engine();
-    if(!engine)
-      return nullptr;
+    return nullptr;
   }
 
   RenderUserData* newData = nullptr;
@@ -158,7 +154,6 @@ MUserData* ProxyDrawOverride::prepareForDraw(
   data->m_objPath = objPath;
   data->m_shape = shape;
   data->m_rootPrim = shape->getRootPrim();
-  data->m_engine = engine;
 
   return data;
 }
@@ -174,6 +169,12 @@ void ProxyDrawOverride::draw(const MHWRender::MDrawContext& context, const MUser
   RenderUserData* ptr = (RenderUserData*)data;
   if(ptr && ptr->m_rootPrim)
   {
+    auto* engine = ptr->m_shape->engine();
+    if (!engine)
+    {
+      TF_DEBUG(ALUSDMAYA_DRAW).Msg("ProxyDrawOverride::draw - Error constructing usd opengl drawing engine - aborting draw\n");
+      return;
+    }
     MHWRender::MStateManager* stateManager = context.getStateManager();
     MHWRender::MDepthStencilStateDesc depthDesc;
 
@@ -373,18 +374,18 @@ void ProxyDrawOverride::draw(const MHWRender::MDrawContext& context, const MUser
     GLint uboBinding = -1;
     glGetIntegeri_v(GL_UNIFORM_BUFFER_BINDING, 4, &uboBinding);
 
-    ptr->m_engine->SetLightingState(lights, material, GfVec4f(0.05f));
+    engine->SetLightingState(lights, material, GfVec4f(0.05f));
     glDepthFunc(GL_LESS);
 
     int originX, originY, width, height;
     context.getViewportDimensions(originX, originY, width, height);
 
-    ptr->m_engine->SetCameraState(
+    engine->SetCameraState(
         GfMatrix4d(context.getMatrix(MHWRender::MFrameContext::kViewMtx).matrix),
         GfMatrix4d(context.getMatrix(MHWRender::MFrameContext::kProjectionMtx).matrix),
         GfVec4d(originX, originY, width, height));
 
-    ptr->m_engine->SetRootTransform(GfMatrix4d(ptr->m_objPath.inclusiveMatrix().matrix));
+    engine->SetRootTransform(GfMatrix4d(ptr->m_objPath.inclusiveMatrix().matrix));
 
     auto view = M3dView::active3dView();
     const auto& paths1 = ptr->m_shape->selectedPaths();
@@ -394,8 +395,8 @@ void ProxyDrawOverride::draw(const MHWRender::MDrawContext& context, const MUser
     combined.insert(combined.end(), paths1.begin(), paths1.end());
     combined.insert(combined.end(), paths2.begin(), paths2.end());
 
-    ptr->m_engine->SetSelected(combined);
-    ptr->m_engine->SetSelectionColor(GfVec4f(1.0f, 2.0f/3.0f, 0.0f, 1.0f));
+    engine->SetSelected(combined);
+    engine->SetSelectionColor(GfVec4f(1.0f, 2.0f/3.0f, 0.0f, 1.0f));
 
     ptr->m_params.frame = ptr->m_shape->outTimePlug().asMTime().as(MTime::uiUnit());
     if(combined.size())
@@ -405,10 +406,10 @@ void ProxyDrawOverride::draw(const MHWRender::MDrawContext& context, const MUser
       MColor colour = M3dView::leadColor();
       params.wireframeColor = GfVec4f(colour.r, colour.g, colour.b, 1.0f);
       glDepthFunc(GL_LEQUAL);
-      ptr->m_engine->RenderBatch(combined, params);
+      engine->RenderBatch(combined, params);
     }
 
-    ptr->m_engine->Render(ptr->m_rootPrim, ptr->m_params);
+    engine->Render(ptr->m_rootPrim, ptr->m_params);
 
 #if defined(WANT_UFE_BUILD)
     if (ArchHasEnv("MAYA_WANT_UFE_SELECTION"))
@@ -446,7 +447,7 @@ void ProxyDrawOverride::draw(const MHWRender::MDrawContext& context, const MUser
             // lines in front with negative offset.
             glEnable(GL_POLYGON_OFFSET_LINE);
             glPolygonOffset(-1.0, -1.0);
-            ptr->m_engine->RenderBatch(ufePaths, params);
+            engine->RenderBatch(ufePaths, params);
             glDisable(GL_POLYGON_OFFSET_LINE);
         }
     }
@@ -461,7 +462,7 @@ void ProxyDrawOverride::draw(const MHWRender::MDrawContext& context, const MUser
     // Check framestamp b/c we don't want to put multiple refresh commands
     // on the idle queue for a single frame-render... especially if we have
     // multiple ProxyShapes...
-    if (!ptr->m_engine->IsConverged() && context.getFrameStamp() != s_lastRefreshFrameStamp)
+    if (!engine->IsConverged() && context.getFrameStamp() != s_lastRefreshFrameStamp)
     {
       s_lastRefreshFrameStamp = context.getFrameStamp();
       // Force another refresh of the current viewport
@@ -553,6 +554,7 @@ bool ProxyDrawOverride::userSelect(
 
   auto* proxyShape = static_cast<ProxyShape*>(getShape(objPath));
   auto engine = proxyShape->engine();
+  if (!engine) return false;
   proxyShape->m_pleaseIgnoreSelection = true;
 
   UsdPrim root = proxyShape->getUsdStage()->GetPseudoRoot();

--- a/lib/AL_USDMaya/AL/usdmaya/nodes/ProxyShape.h
+++ b/lib/AL_USDMaya/AL/usdmaya/nodes/ProxyShape.h
@@ -689,14 +689,10 @@ public:
   /// \name   UsdImaging
   //--------------------------------------------------------------------------------------------------------------------
 
-  /// \brief  constructs the USD imaging engine for this shape
+  /// \brief  returns and optionally constructs the usd imaging engine for this proxy shape
+  /// \return the imagine engine instance for this shape (shared between draw override and shape ui)
   AL_USDMAYA_PUBLIC
-  void constructGLImagingEngine();
-
-  /// \brief  returns the usd imaging engine for this proxy shape
-  /// \return the imagine engin instance for this shape (shared between draw override and shape ui)
-  inline Engine* engine() const
-    { return m_engine; }
+  Engine* engine(bool construct=true);
 
   //--------------------------------------------------------------------------------------------------------------------
   /// \name   Miscellaneous
@@ -866,6 +862,11 @@ public:
     { m_boundingBoxCache.clear(); }
 
 private:
+  /// \brief  constructs the USD imaging engine for this shape
+  void constructGLImagingEngine();
+
+  /// \brief destroys the USD imaging engine for this shape
+  void destroyGLImagingEngine();
 
   static void onSelectionChanged(void* ptr);
   bool removeAllSelectedNodes(SelectionUndoHelper& helper);

--- a/lib/AL_USDMaya/AL/usdmaya/nodes/ProxyShapeUI.cpp
+++ b/lib/AL_USDMaya/AL/usdmaya/nodes/ProxyShapeUI.cpp
@@ -101,11 +101,6 @@ void ProxyShapeUI::getDrawRequests(const MDrawInfo& drawInfo, bool isObjectAndAc
   MDrawRequest request = drawInfo.getPrototype(*this);
 
   ProxyShape* shape = static_cast<ProxyShape*>(surfaceShape());
-  Engine* engine = shape->engine();
-  if(!engine)
-  {
-    shape->constructGLImagingEngine();
-  }
 
   // add the request to the queue
   requests.add(request);
@@ -333,6 +328,7 @@ bool ProxyShapeUI::select(MSelectInfo& selectInfo, MSelectionList& selectionList
 
   auto* proxyShape = static_cast<ProxyShape*>(surfaceShape());
   auto engine = proxyShape->engine();
+  if (!engine) return false;
   proxyShape->m_pleaseIgnoreSelection = true;
 
   UsdPrim root = proxyShape->getUsdStage()->GetPseudoRoot();

--- a/lib/AL_USDMaya/AL/usdmaya/nodes/RendererManager.cpp
+++ b/lib/AL_USDMaya/AL/usdmaya/nodes/RendererManager.cpp
@@ -222,7 +222,7 @@ void RendererManager::changeRendererPlugin(ProxyShape* proxy, bool creation)
 {
   TF_DEBUG(ALUSDMAYA_RENDERER).Msg("RendererManager::changeRendererPlugin\n");
   assert(proxy);
-  if (proxy->engine())
+  if (proxy->engine(false))
   {
     int rendererId = getRendererPluginIndex();
     if (rendererId >= 0)


### PR DESCRIPTION
## Description (this won't be part of the changelog)

Currently, if you alter the filepath of ProxyShape that's already been drawn, then nothing will happen in the viewport - ie, it will keep displaying the stage.

I fixed this by making the gl engine constructed on demand (and destroying any old engine after loading a stage).  I also made sure we didn't store refs to the engine, but always query it from the ProxyShape.

(Note: I confirmed that this is not related to the recent changes which were merged, including https://github.com/AnimalLogic/AL_USDMaya/pull/89).

## Changelog
### Fixed
- fix issue where proxy shape wasn't redrawn when filepath was changed 

## Checklist (Please do not remove this line)
- [X] Make sure the Title and Description of the PR make sense and  provide sufficient context for your work
- [X] Do any added files have the correct AL Apache Licence Header?
- [X] Are there Doxygen comments in the headers?
- [X] Are any new features, behaviour changes documented in the .md format [documentation](https://github.com/AnimalLogic/AL_USDMaya/docs)?
- [ ] Have you added, updated tests to cover new features and behaviour changes?
- [X] Have you filled out at least one changelog entry?
- [X] Is the branch's history clean? (only relevant commits)
