### PR TITLE
Fix for building against latest develop on maya 2018+

### DIFF
--- a/lib/AL_USDMaya/AL/usdmaya/nodes/LayerManager.cpp
+++ b/lib/AL_USDMaya/AL/usdmaya/nodes/LayerManager.cpp
@@ -29,12 +29,9 @@
 #include "maya/MItDependencyNodes.h"
 #include "maya/MPlugArray.h"
 
-#if MAYA_API_VERSION < 201800
-//@todo: Not sure where these are being pulled in from in Maya 2018+, but we should replace with more standard fare
 #include <boost/thread.hpp>
 #include <boost/thread/shared_lock_guard.hpp>
 #include <mutex>
-#endif
 
 namespace {
   // Global mutex protecting _findNode / findOrCreateNode.


### PR DESCRIPTION
## Description (this won't be part of the changelog)

The latest develop did not build for me, on any version of maya >= 2018.  This was because of a conditional include of a boost header, so that it was only added if maya < 2018.

## Changelog
### Fixed
- Fixes compilation against maya 2018+

## Checklist (Please do not remove this line)
- [X] Make sure the Title and Description of the PR make sense and  provide sufficient context for your work
- [X] Do any added files have the correct AL Apache Licence Header?
- [X] Are there Doxygen comments in the headers?
- [X] Are any new features, behaviour changes documented in the .md format [documentation](https://github.com/AnimalLogic/AL_USDMaya/docs)?
- [ ] Have you added, updated tests to cover new features and behaviour changes?
- [X] Have you filled out at least one changelog entry?
- [X] Is the branch's history clean? (only relevant commits)
