### PR TITLE
Use the nearestToCamera mode in HdxIntersector

### DIFF
--- a/lib/AL_USDMaya/AL/usdmaya/PluginRegister.h
+++ b/lib/AL_USDMaya/AL/usdmaya/PluginRegister.h
@@ -47,6 +47,7 @@
 
 #include "pxr/base/plug/plugin.h"
 #include "pxr/base/plug/registry.h"
+#include "pxr/imaging/glf/contextCaps.h"
 
 #include "maya/MDrawRegistry.h"
 #include "maya/MGlobal.h"
@@ -162,6 +163,7 @@ template<typename AFnPlugin>
 MStatus registerPlugin(AFnPlugin& plugin)
 {
   GlfGlewInit();
+  GlfContextCaps::InitInstance();
 
   if(!MGlobal::optionVarExists("AL_usdmaya_selectMode"))
   {

--- a/lib/AL_USDMaya/AL/usdmaya/nodes/Engine.cpp
+++ b/lib/AL_USDMaya/AL/usdmaya/nodes/Engine.cpp
@@ -40,7 +40,6 @@
 #include "AL/usdmaya/nodes/Engine.h"
 
 #include "pxr/imaging/hdx/intersector.h"
-#include "pxr/imaging/hdx/taskController.h"
 
 namespace AL {
 namespace usdmaya {
@@ -55,6 +54,7 @@ bool Engine::TestIntersectionBatch(
   const GfMatrix4d &worldToLocalSpace,
   const SdfPathVector& paths,
   UsdImagingGLRenderParams params,
+  const TfToken &intersectionMode,
   unsigned int pickResolution,
   PathTranslatorCallback pathTranslator,
   HitBatch *outHit) {
@@ -95,7 +95,7 @@ bool Engine::TestIntersectionBatch(
       &_engine,
       _intersectCollection,
       qparams,
-      HdxIntersectionModeTokens->unique,
+      intersectionMode,
       &allHits)) {
     return false;
   }

--- a/lib/AL_USDMaya/AL/usdmaya/nodes/Engine.cpp
+++ b/lib/AL_USDMaya/AL/usdmaya/nodes/Engine.cpp
@@ -105,16 +105,9 @@ bool Engine::TestIntersectionBatch(
   }
 
   for (const auto& hit : allHits) {
-    const SdfPath primPath = hit.objectId;
-    const SdfPath instancerPath = hit.instancerId;
-    const int instanceIndex = hit.instanceIndex;
-
-    HitInfo& info = (*outHit)[pathTranslator(primPath, instancerPath,
-                                             instanceIndex)];
-    info.worldSpaceHitPoint = GfVec3d(hit.worldSpaceHitPoint[0],
-                                      hit.worldSpaceHitPoint[1],
-                                      hit.worldSpaceHitPoint[2]);
-    info.hitInstanceIndex = instanceIndex;
+    const SdfPath usdPath = pathTranslator(hit.objectId, hit.instancerId,
+        hit.instanceIndex);
+    (*outHit)[usdPath] = hit.worldSpaceHitPoint;
   }
 
   return true;

--- a/lib/AL_USDMaya/AL/usdmaya/nodes/Engine.h
+++ b/lib/AL_USDMaya/AL/usdmaya/nodes/Engine.h
@@ -30,11 +30,7 @@ public:
   Engine(const SdfPath& rootPath,
          const SdfPathVector& excludedPaths);
 
-  struct HitInfo {
-    GfVec3d worldSpaceHitPoint;
-    int hitInstanceIndex;
-  };
-  typedef TfHashMap<SdfPath, HitInfo, SdfPath::Hash> HitBatch;
+  typedef TfHashMap<SdfPath, GfVec3d, SdfPath::Hash> HitBatch;
 
   typedef std::function<SdfPath(const SdfPath&, const SdfPath&, const int)> PathTranslatorCallback;
 

--- a/lib/AL_USDMaya/AL/usdmaya/nodes/Engine.h
+++ b/lib/AL_USDMaya/AL/usdmaya/nodes/Engine.h
@@ -15,6 +15,7 @@
 //
 #pragma once
 
+#include "pxr/imaging/hdx/taskController.h"
 #include "pxr/usdImaging/usdImagingGL/engine.h"
 #include "pxr/usdImaging/usdImagingGL/renderParams.h"
 
@@ -43,6 +44,7 @@ public:
     const GfMatrix4d &worldToLocalSpace,
     const SdfPathVector& paths,
     UsdImagingGLRenderParams params,
+    const TfToken &intersectionMode,
     unsigned int pickResolution,
     PathTranslatorCallback pathTranslator,
     HitBatch *outHit);

--- a/lib/AL_USDMaya/AL/usdmaya/nodes/ProxyDrawOverride.cpp
+++ b/lib/AL_USDMaya/AL/usdmaya/nodes/ProxyDrawOverride.cpp
@@ -484,21 +484,6 @@ ProxyShape* ProxyDrawOverride::getShape(const MDagPath& objPath)
   return static_cast<ProxyShape*>(dnNode.userNode());
 }
 
-//----------------------------------------------------------------------------------------------------------------------
-class ProxyDrawOverrideSelectionHelper
-{
-public:
-
-  static SdfPath path_ting(const SdfPath& a, const SdfPath& b, const int c)
-  {
-    m_paths.push_back(a);
-    return a;
-  }
-  static SdfPathVector m_paths;
-};
-SdfPathVector ProxyDrawOverrideSelectionHelper::m_paths;
-
-
 #if MAYA_API_VERSION >= 20190000
 //----------------------------------------------------------------------------------------------------------------------
 bool ProxyDrawOverride::userSelect(
@@ -566,6 +551,20 @@ bool ProxyDrawOverride::userSelect(
   if (resolution < 10) { resolution = 10; }
   if (resolution > 1024) { resolution = 1024; }
 
+  auto getHitPath = [&engine] (
+      const SdfPath& inPrimPath,
+      const SdfPath& instancerPath,
+      const int instanceIndex) -> SdfPath
+  {
+    auto path = engine->GetPrimPathFromInstanceIndex(inPrimPath, instanceIndex);
+    if (!path.IsEmpty())
+    {
+      return path;
+    }
+
+    return inPrimPath.StripAllVariantSelections();
+  };
+
   TfToken intersectionMode = selectInfo.singleSelection()
       ? HdxIntersectionModeTokens->nearestToCamera
       : HdxIntersectionModeTokens->unique;
@@ -578,27 +577,13 @@ bool ProxyDrawOverride::userSelect(
           params,
           intersectionMode,
           resolution,
-          ProxyDrawOverrideSelectionHelper::path_ting,
+          getHitPath,
           &hitBatch);
 
   auto selected = false;
 
-  auto getHitPath = [&engine] (Engine::HitBatch::const_reference& it) -> SdfPath
-  {
-    const Engine::HitInfo& hit = it.second;
-    auto path = engine->GetPrimPathFromInstanceIndex(it.first, hit.hitInstanceIndex);
-    if (!path.IsEmpty())
-    {
-      return path;
-    }
-
-    return it.first.StripAllVariantSelections();
-  };
-
-
   auto addSelection = [&hitBatch, &selectInfo, &selectionList,
-    &worldSpaceHitPts, proxyShape, &selected,
-    &getHitPath] (const MString& command)
+    &worldSpaceHitPts, proxyShape, &selected] (const MString& command)
   {
     selected = true;
     MStringArray nodes;
@@ -606,7 +591,7 @@ bool ProxyDrawOverride::userSelect(
     
     for(const auto& it : hitBatch)
     {
-      auto path = getHitPath(it).StripAllVariantSelections();
+      auto path = it.first.StripAllVariantSelections();
       auto obj = proxyShape->findRequiredPath(path);
       if (obj != MObject::kNullObj) 
       {
@@ -662,9 +647,8 @@ bool ProxyDrawOverride::userSelect(
 
       for(const auto& it : hitBatch)
       {
-        auto path = getHitPath(it);
         command += " -pp \"";
-        command += path.GetText();
+        command += it.first.GetText();
         command += "\"";
       }
 
@@ -692,7 +676,7 @@ bool ProxyDrawOverride::userSelect(
       paths.reserve(hitBatch.size());
       for (const auto& it : hitBatch)
       {
-        paths.push_back(getHitPath(it));
+        paths.push_back(it.first);
       }
     }
 
@@ -898,8 +882,6 @@ bool ProxyDrawOverride::userSelect(
 #endif
   }
 
-  ProxyDrawOverrideSelectionHelper::m_paths.clear();
-  
   return selected;
 }
 #endif

--- a/lib/AL_USDMaya/AL/usdmaya/nodes/ProxyDrawOverride.cpp
+++ b/lib/AL_USDMaya/AL/usdmaya/nodes/ProxyDrawOverride.cpp
@@ -566,6 +566,9 @@ bool ProxyDrawOverride::userSelect(
   if (resolution < 10) { resolution = 10; }
   if (resolution > 1024) { resolution = 1024; }
 
+  TfToken intersectionMode = selectInfo.singleSelection()
+      ? HdxIntersectionModeTokens->nearestToCamera
+      : HdxIntersectionModeTokens->unique;
 
   bool hitSelected = engine->TestIntersectionBatch(
           GfMatrix4d(worldViewMatrix.matrix),
@@ -573,6 +576,7 @@ bool ProxyDrawOverride::userSelect(
           worldToLocalSpace,
           rootPath,
           params,
+          intersectionMode,
           resolution,
           ProxyDrawOverrideSelectionHelper::path_ting,
           &hitBatch);
@@ -686,51 +690,9 @@ bool ProxyDrawOverride::userSelect(
     if (!hitBatch.empty())
     {
       paths.reserve(hitBatch.size());
-
-      auto addHit = [&engine, &paths, &getHitPath](Engine::HitBatch::const_reference& it)
+      for (const auto& it : hitBatch)
       {
         paths.push_back(getHitPath(it));
-      };
-
-      // Do to the inaccuracies in the selection method in gl engine
-      // we still need to find the closest selection.
-      // Around the edges it often selects two or more prims.
-      if (selectInfo.singleSelection())
-      {
-        auto closestHit = hitBatch.cbegin();
-
-        if (hitBatch.size() > 1)
-        {
-          MDagPath cameraPath;
-          M3dView::active3dView().getCamera(cameraPath);
-          const auto cameraPoint = cameraPath.inclusiveMatrix() * MPoint(0.0, 0.0, 0.0, 1.0);
-          auto distanceToCameraSq = [&cameraPoint] (Engine::HitBatch::const_reference& it) -> double
-          {
-            const auto dx = cameraPoint.x - it.second.worldSpaceHitPoint[0];
-            const auto dy = cameraPoint.y - it.second.worldSpaceHitPoint[1];
-            const auto dz = cameraPoint.z - it.second.worldSpaceHitPoint[2];
-            return dx * dx + dy * dy + dz * dz;
-          };
-
-          auto closestDistance = distanceToCameraSq(*closestHit);
-          for (auto it = ++hitBatch.cbegin(), itEnd = hitBatch.cend(); it != itEnd; ++it)
-          {
-            const auto currentDistance = distanceToCameraSq(*it);
-            if (currentDistance < closestDistance)
-            {
-              closestDistance = currentDistance;
-              closestHit = it;
-            }
-          }
-        }
-        addHit(*closestHit);
-      }
-      else
-      {
-        for (const auto& it : hitBatch)
-        {
-          addHit(it);
-        }
       }
     }
 

--- a/lib/AL_USDMaya/AL/usdmaya/nodes/ProxyDrawOverride.cpp
+++ b/lib/AL_USDMaya/AL/usdmaya/nodes/ProxyDrawOverride.cpp
@@ -598,7 +598,7 @@ bool ProxyDrawOverride::userSelect(
         MFnDagNode dagNode(obj);
         MDagPath dg;
         dagNode.getPath(dg);
-        const double* p = it.second.worldSpaceHitPoint.GetArray();
+        const double* p = it.second.GetArray();
         
         selectionList.add(dg);
         worldSpaceHitPts.append(MPoint(p[0], p[1], p[2]));

--- a/lib/AL_USDMaya/AL/usdmaya/nodes/ProxyShapeUI.cpp
+++ b/lib/AL_USDMaya/AL/usdmaya/nodes/ProxyShapeUI.cpp
@@ -346,12 +346,17 @@ bool ProxyShapeUI::select(MSelectInfo& selectInfo, MSelectionList& selectionList
   if (resolution < 10) { resolution = 10; }
   if (resolution > 1024) { resolution = 1024; }
 
+  TfToken intersectionMode = selectInfo.singleSelection()
+      ? HdxIntersectionModeTokens->nearestToCamera
+      : HdxIntersectionModeTokens->unique;
+
   bool hitSelected = engine->TestIntersectionBatch(
           GfMatrix4d(viewMatrix.matrix),
           GfMatrix4d(projectionMatrix.matrix),
           worldToLocalSpace,
           rootPath,
           params,
+          intersectionMode,
           resolution,
           ProxyShapeSelectionHelper::path_ting,
           &hitBatch);
@@ -486,51 +491,9 @@ bool ProxyShapeUI::select(MSelectInfo& selectInfo, MSelectionList& selectionList
     if (!hitBatch.empty())
     {
       paths.reserve(hitBatch.size());
-
-      auto addHit = [&engine, &paths, &getHitPath](Engine::HitBatch::const_reference& it)
+      for (const auto& it : hitBatch)
       {
         paths.push_back(getHitPath(it));
-      };
-
-      // Do to the inaccuracies in the selection method in gl engine
-      // we still need to find the closest selection.
-      // Around the edges it often selects two or more prims.
-      if (selectInfo.singleSelection())
-      {
-        auto closestHit = hitBatch.cbegin();
-
-        if (hitBatch.size() > 1)
-        {
-          MDagPath cameraPath;
-          selectInfo.view().getCamera(cameraPath);
-          const auto cameraPoint = cameraPath.inclusiveMatrix() * MPoint(0.0, 0.0, 0.0, 1.0);
-          auto distanceToCameraSq = [&cameraPoint] (Engine::HitBatch::const_reference& it) -> double
-          {
-            const auto dx = cameraPoint.x - it.second.worldSpaceHitPoint[0];
-            const auto dy = cameraPoint.y - it.second.worldSpaceHitPoint[1];
-            const auto dz = cameraPoint.z - it.second.worldSpaceHitPoint[2];
-            return dx * dx + dy * dy + dz * dz;
-          };
-
-          auto closestDistance = distanceToCameraSq(*closestHit);
-          for (auto it = ++hitBatch.cbegin(), itEnd = hitBatch.cend(); it != itEnd; ++it)
-          {
-            const auto currentDistance = distanceToCameraSq(*it);
-            if (currentDistance < closestDistance)
-            {
-              closestDistance = currentDistance;
-              closestHit = it;
-            }
-          }
-        }
-        addHit(*closestHit);
-      }
-      else
-      {
-        for (const auto& it : hitBatch)
-        {
-          addHit(it);
-        }
       }
     }
 #if defined(WANT_UFE_BUILD)

--- a/lib/AL_USDMaya/AL/usdmaya/nodes/ProxyShapeUI.cpp
+++ b/lib/AL_USDMaya/AL/usdmaya/nodes/ProxyShapeUI.cpp
@@ -391,7 +391,7 @@ bool ProxyShapeUI::select(MSelectInfo& selectInfo, MSelectionList& selectionList
         MDagPath dg;
         dagNode.getPath(dg);
         sl.add(dg);
-        const double* d = it.second.worldSpaceHitPoint.GetArray();
+        const double* d = it.second.GetArray();
         selectInfo.addSelection(sl, MPoint(d[0], d[1], d[2], 1.0), selectionList, worldSpaceSelectPoints, objectsMask, false);
       }
     }

--- a/lib/AL_USDMaya/AL/usdmaya/nodes/ProxyShapeUI.cpp
+++ b/lib/AL_USDMaya/AL/usdmaya/nodes/ProxyShapeUI.cpp
@@ -288,21 +288,6 @@ void ProxyShapeUI::draw(const MDrawRequest& request, M3dView& view) const
 }
 
 //----------------------------------------------------------------------------------------------------------------------
-class ProxyShapeSelectionHelper
-{
-public:
-
-  static SdfPath path_ting(const SdfPath& a, const SdfPath& b, const int c)
-  {
-    m_paths.push_back(a);
-    return a;
-  }
-  static SdfPathVector m_paths;
-};
-SdfPathVector ProxyShapeSelectionHelper::m_paths;
-
-
-//----------------------------------------------------------------------------------------------------------------------
 bool ProxyShapeUI::select(MSelectInfo& selectInfo, MSelectionList& selectionList, MPointArray& worldSpaceSelectPoints) const
 {
   TF_DEBUG(ALUSDMAYA_DRAW).Msg("ProxyShapeUI::select\n");
@@ -346,6 +331,19 @@ bool ProxyShapeUI::select(MSelectInfo& selectInfo, MSelectionList& selectionList
   if (resolution < 10) { resolution = 10; }
   if (resolution > 1024) { resolution = 1024; }
 
+  auto getHitPath = [&engine] (
+      const SdfPath& inPrimPath,
+      const SdfPath& instancerPath,
+      const int instanceIndex) -> SdfPath
+  {
+    auto path = engine->GetPrimPathFromInstanceIndex(inPrimPath, instanceIndex);
+    if (!path.IsEmpty())
+    {
+      return path;
+    }
+    return inPrimPath.StripAllVariantSelections();
+  };
+
   TfToken intersectionMode = selectInfo.singleSelection()
       ? HdxIntersectionModeTokens->nearestToCamera
       : HdxIntersectionModeTokens->unique;
@@ -358,26 +356,14 @@ bool ProxyShapeUI::select(MSelectInfo& selectInfo, MSelectionList& selectionList
           params,
           intersectionMode,
           resolution,
-          ProxyShapeSelectionHelper::path_ting,
+          getHitPath,
           &hitBatch);
 
   auto selected = false;
 
-  auto getHitPath = [&engine] (const Engine::HitBatch::const_reference& it) -> SdfPath
-  {
-    const Engine::HitInfo& hit = it.second;
-    auto path = engine->GetPrimPathFromInstanceIndex(it.first, hit.hitInstanceIndex);
-    if (!path.IsEmpty())
-    {
-      return path;
-    }
-    return it.first.StripAllVariantSelections();
-  };
-
-
   auto addSelection = [&hitBatch, &selectInfo, &selectionList,
-      &worldSpaceSelectPoints, &objectsMask, &selected, proxyShape,
-      &getHitPath] (const MString& command)
+      &worldSpaceSelectPoints, &objectsMask, &selected, proxyShape]
+      (const MString& command)
   {
     selected = true;
     MStringArray nodes;
@@ -394,7 +380,7 @@ bool ProxyShapeUI::select(MSelectInfo& selectInfo, MSelectionList& selectionList
 
       // Retarget hit path based on pick mode policy. The retargeted prim must
       // align with the path used in the 'AL_usdmaya_ProxyShapeSelect' command.
-      const SdfPath hitPath = getHitPath(it).StripAllVariantSelections();
+      const SdfPath hitPath = it.first.StripAllVariantSelections();
       const UsdPrim retargetedHitPrim = retargetSelectPrim(proxyShape->getUsdStage()->GetPrimAtPath(hitPath));
       const MObject obj = proxyShape->findRequiredPath(retargetedHitPrim.GetPath());
 
@@ -447,9 +433,8 @@ bool ProxyShapeUI::select(MSelectInfo& selectInfo, MSelectionList& selectionList
 
       for(const auto& it : hitBatch)
       {
-        auto path = getHitPath(it);
         command += " -pp \"";
-        command += path.GetText();
+        command += it.first.GetText();
         command += "\"";
       }
 
@@ -493,7 +478,7 @@ bool ProxyShapeUI::select(MSelectInfo& selectInfo, MSelectionList& selectionList
       paths.reserve(hitBatch.size());
       for (const auto& it : hitBatch)
       {
-        paths.push_back(getHitPath(it));
+        paths.push_back(it.first);
       }
     }
 #if defined(WANT_UFE_BUILD)
@@ -717,8 +702,6 @@ bool ProxyShapeUI::select(MSelectInfo& selectInfo, MSelectionList& selectionList
   } // else MAYA_WANT_UFE_SELECTION
 #endif
   }
-
-  ProxyShapeSelectionHelper::m_paths.clear();
 
   // restore clear colour
   glClearColor(clearCol[0], clearCol[1], clearCol[2], clearCol[3]);


### PR DESCRIPTION
## Description (this won't be part of the changelog)

By making use of this new mode, we can significantly simplify some of the selection code.
Should also be slightly more efficient, as we avoid doing any processing or transfer of hits we won't actually end up using / needing.

Note that this PR branches off of https://github.com/AnimalLogic/AL_USDMaya/pull/150, as it relies on changes made in usd-0.19.5.

## Changelog
### Changed
- Make selection using HdxIntersector's nearestToCamera mode, instead of doing the work ourselves

## Checklist (Please do not remove this line)
- [X] Make sure the Title and Description of the PR make sense and  provide sufficient context for your work
- [X] Do any added files have the correct AL Apache Licence Header?
- [X] Are there Doxygen comments in the headers?
- [X] Are any new features, behaviour changes documented in the .md format [documentation](https://github.com/AnimalLogic/AL_USDMaya/docs)?
- [ ] Have you added, updated tests to cover new features and behaviour changes?
- [X] Have you filled out at least one changelog entry?
- [X] Is the branch's history clean? (only relevant commits)
