### PR TITLE
if renderGuides are shown, they should be selectable

### DIFF
--- a/lib/AL_USDMaya/AL/usdmaya/nodes/ProxyDrawOverride.cpp
+++ b/lib/AL_USDMaya/AL/usdmaya/nodes/ProxyDrawOverride.cpp
@@ -550,12 +550,15 @@ bool ProxyDrawOverride::userSelect(
   MMatrix invMatrix = objPath.inclusiveMatrixInverse();
   GfMatrix4d worldToLocalSpace(invMatrix.matrix);
 
-  UsdImagingGLRenderParams params;
 
   auto* proxyShape = static_cast<ProxyShape*>(getShape(objPath));
   auto engine = proxyShape->engine();
   if (!engine) return false;
   proxyShape->m_pleaseIgnoreSelection = true;
+
+  UsdImagingGLRenderParams params;
+  // Mostly want to get render params to set renderGuides/proxyGuides/etc
+  proxyShape->getRenderAttris(params, context, objPath);
 
   UsdPrim root = proxyShape->getUsdStage()->GetPseudoRoot();
 

--- a/lib/AL_USDMaya/AL/usdmaya/nodes/ProxyShapeUI.cpp
+++ b/lib/AL_USDMaya/AL/usdmaya/nodes/ProxyShapeUI.cpp
@@ -316,7 +316,6 @@ bool ProxyShapeUI::select(MSelectInfo& selectInfo, MSelectionList& selectionList
   MDagPath selectPath = selectInfo.selectPath();
   MMatrix invMatrix = selectPath.inclusiveMatrixInverse();
 
-  UsdImagingGLRenderParams params;
   MMatrix viewMatrix, projectionMatrix;
   GfMatrix4d worldToLocalSpace(invMatrix.matrix);
 
@@ -330,6 +329,10 @@ bool ProxyShapeUI::select(MSelectInfo& selectInfo, MSelectionList& selectionList
   auto engine = proxyShape->engine();
   if (!engine) return false;
   proxyShape->m_pleaseIgnoreSelection = true;
+
+  UsdImagingGLRenderParams params;
+  params.showGuides = proxyShape->displayGuidesPlug().asBool();
+  params.showRender = proxyShape->displayRenderGuidesPlug().asBool();
 
   UsdPrim root = proxyShape->getUsdStage()->GetPseudoRoot();
 


### PR DESCRIPTION
## Description (this won't be part of the changelog)

If "displayRenderGuides" is checked on, then prims whose purpose is "render" will be displayed, but they will not be selectable.  This is confusing, at best, for artists.

This PR makes it so that if objects whose purpose is "render" or "guide" are displayed, they are selectable.  (I'm assuming this was a bug, as the docs state that you "can select any prim being displayed.  If it was deliberate, then it should probably be turned into a separate option, and the docs updated.)

## Changelog
### Fixed
- Prims with "render" and "guide" purpose are now selectable if they are displayed

## Checklist (Please do not remove this line)
- [X] Make sure the Title and Description of the PR make sense and  provide sufficient context for your work
- [X] Do any added files have the correct AL Apache Licence Header?
- [X] Are there Doxygen comments in the headers?
- [X] Are any new features, behaviour changes documented in the .md format [documentation](https://github.com/AnimalLogic/AL_USDMaya/docs)?
- [ ] Have you added, updated tests to cover new features and behaviour changes?
- [X] Have you filled out at least one changelog entry?
- [X] Is the branch's history clean? (only relevant commits)
