### PR TITLE
Methods to query information about renderer plugins are now static

### DIFF
--- a/lib/AL_USDMaya/AL/usdmaya/nodes/RendererManager.cpp
+++ b/lib/AL_USDMaya/AL/usdmaya/nodes/RendererManager.cpp
@@ -53,9 +53,7 @@ MStatus RendererManager::initialise()
     addFrame("Renderer plugin");
 
     // hydra renderer plugin discovery
-    // create dummy imaging engine to get renderer names
-    Engine imagingEngine(SdfPath(), {});
-    m_rendererPluginsTokens = imagingEngine.GetRendererPlugins();
+    m_rendererPluginsTokens = UsdImagingGLEngine::GetRendererPlugins();
     const size_t numTokens = m_rendererPluginsTokens.size();
     m_rendererPluginsNames = MStringArray(numTokens, MString());
 
@@ -66,7 +64,7 @@ MStatus RendererManager::initialise()
     std::vector<int16_t> enumValues(numTokens, -1);
     for (size_t i = 0; i < numTokens; ++i)
     {
-      pluginNames[i] = imagingEngine.GetRendererDisplayName(m_rendererPluginsTokens[i]);
+      pluginNames[i] = UsdImagingGLEngine::GetRendererDisplayName(m_rendererPluginsTokens[i]);
       m_rendererPluginsNames[i] = MString(pluginNames[i].data(), pluginNames[i].size());
       enumNames[i] = pluginNames[i].data();
       enumValues[i] = i;


### PR DESCRIPTION
## Description (this won't be part of the changelog)

...so no need to create a dummy Engine
In addition to being cleaner, this also eliminates an error I was seeing
when loading AL_USDMaya from a non-gui maya session (though it's possible
the error is only visible if using TF_DEBUG=TF_LOG_STACK_TRACE_ON_ERROR)

## Changelog
### Fixed
- error message when loading AL_USDMaya from a non-gui maya session

## Checklist (Please do not remove this line)
- [X] Make sure the Title and Description of the PR make sense and  provide sufficient context for your work
- [X] Do any added files have the correct AL Apache Licence Header?
- [X] Are there Doxygen comments in the headers?
- [X] Are any new features, behaviour changes documented in the .md format [documentation](https://github.com/AnimalLogic/AL_USDMaya/docs)?
- [ ] Have you added, updated tests to cover new features and behaviour changes?
- [X] Have you filled out at least one changelog entry?
- [X] Is the branch's history clean? (only relevant commits)
