### PR TITLE
fix issue where some transformations get lost

### DIFF
--- a/lib/AL_USDMaya/AL/usdmaya/nodes/TransformationMatrix.cpp
+++ b/lib/AL_USDMaya/AL/usdmaya/nodes/TransformationMatrix.cpp
@@ -894,13 +894,15 @@ void TransformationMatrix::initialiseToPrim(bool readFromPrim, Transform* transf
         }
         if(readFromPrim)
         {
-          internal_readVector(m_translationFromUsd, op);
+          MVector tempTranslation;
+          internal_readVector(tempTranslation, op);
           if(transformNode)
           {
-            MPlug(transformNode->thisMObject(), MPxTransform::translateX).setValue(m_translationFromUsd.x);
-            MPlug(transformNode->thisMObject(), MPxTransform::translateY).setValue(m_translationFromUsd.y);
-            MPlug(transformNode->thisMObject(), MPxTransform::translateZ).setValue(m_translationFromUsd.z);
+            MPlug(transformNode->thisMObject(), MPxTransform::translateX).setValue(tempTranslation.x);
+            MPlug(transformNode->thisMObject(), MPxTransform::translateY).setValue(tempTranslation.y);
+            MPlug(transformNode->thisMObject(), MPxTransform::translateZ).setValue(tempTranslation.z);
           }
+          m_translationFromUsd = tempTranslation;
         }
       }
       break;
@@ -1042,13 +1044,15 @@ void TransformationMatrix::initialiseToPrim(bool readFromPrim, Transform* transf
         }
         if(readFromPrim)
         {
-          internal_readShear(m_shearFromUsd, op);
+          MVector tempShear;
+          internal_readShear(tempShear, op);
           if(transformNode)
           {
-            MPlug(transformNode->thisMObject(), MPxTransform::shearXY).setValue(m_shearFromUsd.x);
-            MPlug(transformNode->thisMObject(), MPxTransform::shearXZ).setValue(m_shearFromUsd.y);
-            MPlug(transformNode->thisMObject(), MPxTransform::shearYZ).setValue(m_shearFromUsd.z);
+            MPlug(transformNode->thisMObject(), MPxTransform::shearXY).setValue(tempShear.x);
+            MPlug(transformNode->thisMObject(), MPxTransform::shearXZ).setValue(tempShear.y);
+            MPlug(transformNode->thisMObject(), MPxTransform::shearYZ).setValue(tempShear.z);
           }
+          m_shearFromUsd = tempShear;
         }
       }
       break;
@@ -1062,13 +1066,15 @@ void TransformationMatrix::initialiseToPrim(bool readFromPrim, Transform* transf
         }
         if(readFromPrim)
         {
-          internal_readVector(m_scaleFromUsd, op);
+          MVector tempScale(1.0,1.0,1.0);
+          internal_readVector(tempScale, op);
           if(transformNode)
           {
-            MPlug(transformNode->thisMObject(), MPxTransform::scaleX).setValue(m_scaleFromUsd.x);
-            MPlug(transformNode->thisMObject(), MPxTransform::scaleY).setValue(m_scaleFromUsd.y);
-            MPlug(transformNode->thisMObject(), MPxTransform::scaleZ).setValue(m_scaleFromUsd.z);
+            MPlug(transformNode->thisMObject(), MPxTransform::scaleX).setValue(tempScale.x);
+            MPlug(transformNode->thisMObject(), MPxTransform::scaleY).setValue(tempScale.y);
+            MPlug(transformNode->thisMObject(), MPxTransform::scaleZ).setValue(tempScale.z);
           }
+          m_scaleFromUsd = tempScale;
         }
         
       }


### PR DESCRIPTION
## Description (this won't be part of the changelog)
These changes solve an issue where transformations get lost (reset) when deselecting objects. To reproduce:

- Bring simple object (sphere, cube, ...) as a proxyShape into Maya
- Select object
- Transform object: for instance, translate 5 units in Y (it has to be Y or X - it'll work with X)
- Deselect object
- Select object again and it'll reset back to Y=0

This is related to PR #149 
Note: this only fixes translation, scale and shear. Rotation already worked. The pivot related transformations still fail and need a deeper look 

## Changelog

### Added

### Changed
Added temp variables to store transformations inside TransformationMatrix::initialiseToPrim
### Deprecated

### Removed

### Fixed

## Checklist (Please do not remove this line)
- [x] Make sure the Title and Description of the PR make sense and  provide sufficient context for your work
- [ ] Do any added files have the correct AL Apache Licence Header?
- [ ] Are there Doxygen comments in the headers?
- [ ] Are any new features, behaviour changes documented in the .md format [documentation](https://github.com/AnimalLogic/AL_USDMaya/docs)?
- [ ] Have you added, updated tests to cover new features and behaviour changes?
- [x] Have you filled out at least one changelog entry?
- [x] Is the branch's history clean? (only relevant commits)
