### PR TITLE
fixes crash in import_instances test

### DIFF
--- a/plugin/AL_USDMayaTestPlugin/AL/usdmaya/fileio/import_instances.cpp
+++ b/plugin/AL_USDMayaTestPlugin/AL/usdmaya/fileio/import_instances.cpp
@@ -65,7 +65,7 @@ TEST(import_instances, merged)
   {
     auto it = expectedTransforms.find(xformResults[i].asChar());
     ASSERT_TRUE(it != expectedTransforms.end());
-    expectedTransforms.erase(it);
+    expectedTransforms.erase(*it);
   }
 
   EXPECT_EQ(0, expectedTransforms.size());
@@ -128,7 +128,7 @@ TEST(import_instances, unmerged)
   {
     auto it = expectedTransforms.find(xformResults[i].asChar());
     ASSERT_TRUE(it != expectedTransforms.end());
-    expectedTransforms.erase(it);
+    expectedTransforms.erase(*it);
   }
 
   EXPECT_EQ(0, expectedTransforms.size());

--- a/plugin/AL_USDMayaTestPlugin/AL/usdmaya/fileio/import_instances.cpp
+++ b/plugin/AL_USDMayaTestPlugin/AL/usdmaya/fileio/import_instances.cpp
@@ -63,9 +63,8 @@ TEST(import_instances, merged)
   uint32_t i = 0;
   for(; i < xformResults.length(); ++i)
   {
-    auto it = expectedTransforms.find(xformResults[i].asChar());
-    ASSERT_TRUE(it != expectedTransforms.end());
-    expectedTransforms.erase(*it);
+    uint32_t removed = expectedTransforms.erase(xformResults[i].asChar());
+    ASSERT_TRUE(removed != 0);
   }
 
   EXPECT_EQ(0, expectedTransforms.size());
@@ -126,9 +125,8 @@ TEST(import_instances, unmerged)
   uint32_t i = 0;
   for(; i < xformResults.length(); ++i)
   {
-    auto it = expectedTransforms.find(xformResults[i].asChar());
-    ASSERT_TRUE(it != expectedTransforms.end());
-    expectedTransforms.erase(*it);
+    uint32_t removed = expectedTransforms.erase(xformResults[i].asChar());
+    ASSERT_TRUE(removed != 0);
   }
 
   EXPECT_EQ(0, expectedTransforms.size());


### PR DESCRIPTION
## Description (this won't be part of the changelog)
We were getting "double delete crashes" in the import_instances test
## Changelog

### Added
We changed the argument of the std::set erase method to be the Key that the iterator points to (instead of the iterator itself). The erase method also accept as argument the key of the element you want to remove. This change fixed the crash for us

### Changed

### Deprecated

### Removed

### Fixed

## Checklist (Please do not remove this line)
- [x] Make sure the Title and Description of the PR make sense and  provide sufficient context for your work
- [ ] Do any added files have the correct AL Apache Licence Header?
- [ ] Are there Doxygen comments in the headers?
- [ ] Are any new features, behaviour changes documented in the .md format [documentation](https://github.com/AnimalLogic/AL_USDMaya/docs)?
- [ ] Have you added, updated tests to cover new features and behaviour changes?
- [x] Have you filled out at least one changelog entry?
- [x] Is the branch's history clean? (only relevant commits)
